### PR TITLE
Fix custom auth

### DIFF
--- a/src/chainlit/client/base.py
+++ b/src/chainlit/client/base.py
@@ -58,6 +58,7 @@ class ElementDict(TypedDict):
     size: Optional[ElementSize]
     language: Optional[str]
     forIds: Optional[List[str]]
+    alt: Optional[str]
 
 
 class ConversationDict(TypedDict):

--- a/src/chainlit/db/__init__.py
+++ b/src/chainlit/db/__init__.py
@@ -1,10 +1,13 @@
 import os
+from pathlib import Path
 
-from chainlit.config import PACKAGE_ROOT, config
+from chainlit.config import PACKAGE_ROOT, config, config_dir
 from chainlit.logger import logger
 
 if os.environ.get("SCHEMA_PATH"):
     SCHEMA_PATH = os.environ.get("SCHEMA_PATH")
+elif os.path.isfile(os.path.join(config_dir, "schema.prisma")):
+    SCHEMA_PATH = os.path.join(config_dir, "schema.prisma")
 else:
     SCHEMA_PATH = os.path.join(PACKAGE_ROOT, "db/prisma/schema.prisma")
 

--- a/src/chainlit/db/__init__.py
+++ b/src/chainlit/db/__init__.py
@@ -1,15 +1,19 @@
 import os
-from pathlib import Path
 
 from chainlit.config import PACKAGE_ROOT, config, config_dir
 from chainlit.logger import logger
 
 if os.environ.get("SCHEMA_PATH"):
     SCHEMA_PATH = os.environ.get("SCHEMA_PATH")
+    logger.info(f"loading prisma schema from SCHEMA_PATH env var: {SCHEMA_PATH}")
 elif os.path.isfile(os.path.join(config_dir, "schema.prisma")):
     SCHEMA_PATH = os.path.join(config_dir, "schema.prisma")
+    logger.info(f"loading prisma schema from the .chainlit config dir: {SCHEMA_PATH}")
 else:
     SCHEMA_PATH = os.path.join(PACKAGE_ROOT, "db/prisma/schema.prisma")
+    logger.info(
+        f"loading the default prisma schema from the chainlit package: {SCHEMA_PATH}"
+    )
 
 
 def db_push():

--- a/src/chainlit/db/__init__.py
+++ b/src/chainlit/db/__init__.py
@@ -24,14 +24,14 @@ def db_push():
 
 
 def init_local_db():
-    use_local_db = config.project.database == "local"
+    use_local_db = config.project.database in ["local", "custom"]
     if use_local_db:
         if not os.path.exists(config.project.local_db_path):
             db_push()
 
 
 def migrate_local_db():
-    use_local_db = config.project.database == "local"
+    use_local_db = config.project.database in ["local", "custom"]
     if use_local_db:
         if os.path.exists(config.project.local_db_path):
             db_push()

--- a/src/chainlit/db/__init__.py
+++ b/src/chainlit/db/__init__.py
@@ -3,7 +3,10 @@ import os
 from chainlit.config import PACKAGE_ROOT, config
 from chainlit.logger import logger
 
-SCHEMA_PATH = os.path.join(PACKAGE_ROOT, "db/prisma/schema.prisma")
+if os.environ.get("SCHEMA_PATH"):
+    SCHEMA_PATH = os.environ.get("SCHEMA_PATH")
+else:
+    SCHEMA_PATH = os.path.join(PACKAGE_ROOT, "db/prisma/schema.prisma")
 
 
 def db_push():

--- a/src/chainlit/db/prisma/schema.prisma
+++ b/src/chainlit/db/prisma/schema.prisma
@@ -9,7 +9,7 @@ generator client {
 }
 
 model User {
-  id            String            @id @default(uuid())
+  id            Int            @id @default(autoincrement())
   createdAt     DateTime       @default(now())
   email         String?        @unique
   name          String?
@@ -22,7 +22,7 @@ model Conversation {
   createdAt DateTime  @default(now())
   messages  Message[]
   elements  Element[]
-  authorId  String?
+  authorId  Int?
   author    User?     @relation(fields: [authorId], references: [id])
 }
 

--- a/src/chainlit/db/prisma/schema.prisma
+++ b/src/chainlit/db/prisma/schema.prisma
@@ -9,7 +9,7 @@ generator client {
 }
 
 model User {
-  id            Int            @id @default(autoincrement())
+  id            String            @id @default(uuid())
   createdAt     DateTime       @default(now())
   email         String?        @unique
   name          String?
@@ -22,7 +22,7 @@ model Conversation {
   createdAt DateTime  @default(now())
   messages  Message[]
   elements  Element[]
-  authorId  Int?
+  authorId  String?
   author    User?     @relation(fields: [authorId], references: [id])
 }
 

--- a/src/chainlit/element.py
+++ b/src/chainlit/element.py
@@ -42,6 +42,8 @@ class Element:
     for_ids: List[str] = Field(default_factory=list)
     # The language, if relevant
     language: Optional[str] = None
+    # Alt tag
+    alt: Optional[str] = None
 
     def __post_init__(self) -> None:
         trace_event(f"init {self.__class__.__name__}")
@@ -62,6 +64,7 @@ class Element:
                 "language": getattr(self, "language", None),
                 "forIds": getattr(self, "for_ids", None),
                 "conversationId": None,
+                "alt": self.alt or "",
             }
         )
         return _dict

--- a/src/chainlit/frontend/index.html
+++ b/src/chainlit/frontend/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta data-react-helmet="true" />
     <!-- TAGS INJECTION PLACEHOLDER -->
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/src/chainlit/frontend/package.json
+++ b/src/chainlit/frontend/package.json
@@ -56,6 +56,7 @@
     "@types/node": "^20.0.0",
     "@types/react": "^18.0.27",
     "@types/react-dom": "^18.0.10",
+    "@types/react-helmet": "^6.1.6",
     "@types/react-resizable": "^3.0.4",
     "@types/react-syntax-highlighter": "^15.5.6",
     "@types/react-window-infinite-loader": "^1.0.6",

--- a/src/chainlit/frontend/package.json
+++ b/src/chainlit/frontend/package.json
@@ -26,6 +26,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-dropzone": "^14.2.3",
+    "react-helmet": "^6.1.0",
     "react-hot-toast": "^2.4.0",
     "react-hotkeys-hook": "^4.4.0",
     "react-markdown": "^8.0.6",
@@ -45,7 +46,6 @@
     "yup": "^1.0.2"
   },
   "devDependencies": {
-    "@types/uuid": "^9.0.2",
     "@babel/preset-env": "^7.22.5",
     "@babel/preset-react": "^7.22.5",
     "@babel/preset-typescript": "^7.22.5",
@@ -59,6 +59,7 @@
     "@types/react-resizable": "^3.0.4",
     "@types/react-syntax-highlighter": "^15.5.6",
     "@types/react-window-infinite-loader": "^1.0.6",
+    "@types/uuid": "^9.0.2",
     "@typescript-eslint/eslint-plugin": "^5.59.2",
     "@typescript-eslint/parser": "^5.59.2",
     "@vitejs/plugin-react": "^4.0.1",

--- a/src/chainlit/frontend/pnpm-lock.yaml
+++ b/src/chainlit/frontend/pnpm-lock.yaml
@@ -44,6 +44,9 @@ dependencies:
   react-dropzone:
     specifier: ^14.2.3
     version: 14.2.3(react@18.2.0)
+  react-helmet:
+    specifier: ^6.1.0
+    version: 6.1.0(react@18.2.0)
   react-hot-toast:
     specifier: ^2.4.0
     version: 2.4.0(csstype@3.1.2)(react-dom@18.2.0)(react@18.2.0)
@@ -5064,6 +5067,22 @@ packages:
     resolution: {integrity: sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==}
     dev: false
 
+  /react-fast-compare@3.2.2:
+    resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
+    dev: false
+
+  /react-helmet@6.1.0(react@18.2.0):
+    resolution: {integrity: sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==}
+    peerDependencies:
+      react: '>=16.3.0'
+    dependencies:
+      object-assign: 4.1.1
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-fast-compare: 3.2.2
+      react-side-effect: 2.1.2(react@18.2.0)
+    dev: false
+
   /react-hot-toast@2.4.0(csstype@3.1.2)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-qnnVbXropKuwUpriVVosgo8QrB+IaPJCpL8oBI6Ov84uvHZ5QQcTp2qg6ku2wNfgJl6rlQXJIQU5q+5lmPOutA==}
     engines: {node: '>=10'}
@@ -5163,6 +5182,14 @@ packages:
       react: '>=16.8'
     dependencies:
       '@remix-run/router': 1.3.2
+      react: 18.2.0
+    dev: false
+
+  /react-side-effect@2.1.2(react@18.2.0):
+    resolution: {integrity: sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw==}
+    peerDependencies:
+      react: ^16.3.0 || ^17.0.0 || ^18.0.0
+    dependencies:
       react: 18.2.0
     dev: false
 

--- a/src/chainlit/frontend/pnpm-lock.yaml
+++ b/src/chainlit/frontend/pnpm-lock.yaml
@@ -130,6 +130,9 @@ devDependencies:
   '@types/react-dom':
     specifier: ^18.0.10
     version: 18.0.10
+  '@types/react-helmet':
+    specifier: ^6.1.6
+    version: 6.1.6
   '@types/react-resizable':
     specifier: ^3.0.4
     version: 3.0.4
@@ -2444,6 +2447,12 @@ packages:
 
   /@types/react-dom@18.0.10:
     resolution: {integrity: sha512-E42GW/JA4Qv15wQdqJq8DL4JhNpB3prJgjgapN3qJT9K2zO5IIAQh4VXvCEDupoqAwnz0cY4RlXeC/ajX5SFHg==}
+    dependencies:
+      '@types/react': 18.0.27
+    dev: true
+
+  /@types/react-helmet@6.1.6:
+    resolution: {integrity: sha512-ZKcoOdW/Tg+kiUbkFCBtvDw0k3nD4HJ/h/B9yWxN4uDO8OkRksWTO+EL+z/Qu3aHTeTll3Ro0Cc/8UhwBCMG5A==}
     dependencies:
       '@types/react': 18.0.27
     dev: true

--- a/src/chainlit/frontend/src/components/Head.tsx
+++ b/src/chainlit/frontend/src/components/Head.tsx
@@ -1,0 +1,18 @@
+import { Helmet } from 'react-helmet';
+
+export default function Head({
+  title,
+  description
+}: {
+  title: string;
+  description: string;
+}) {
+  return (
+    <div>
+      <Helmet>
+        <title>{title}</title>
+        <meta name="description" content={description} />
+      </Helmet>
+    </div>
+  );
+}

--- a/src/chainlit/frontend/src/components/Sidebar.tsx
+++ b/src/chainlit/frontend/src/components/Sidebar.tsx
@@ -10,10 +10,11 @@ import Drawer from '@mui/material/Drawer';
 import IconButton from '@mui/material/IconButton';
 import { styled, useTheme } from '@mui/material/styles';
 
-import HarvardIcon from '../assets/HarvardUniversity_Horizontal_Large_Shield_RGB.png';
-import DarkHarvardIcon from '../assets/HarvardUniversity_Horizontal_Large_Shield_Reverse_RGB.png';
-
 const drawerWidth = 340;
+const HarvardIcon =
+  'https://genai-static-temp.s3.amazonaws.com/HarvardUniversity_Horizontal_Large_Shield_RGB.png';
+const DarkHarvardIcon =
+  'https://genai-static-temp.s3.amazonaws.com/HarvardUniversity_Horizontal_Large_Shield_Reverse_RGB.png';
 
 const Main = styled('main', { shouldForwardProp: (prop) => prop !== 'open' })<{
   open?: boolean;

--- a/src/chainlit/frontend/src/components/Sidebar.tsx
+++ b/src/chainlit/frontend/src/components/Sidebar.tsx
@@ -1,0 +1,129 @@
+import * as React from 'react';
+
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import MenuIcon from '@mui/icons-material/DoubleArrow';
+import Box from '@mui/material/Box';
+import CssBaseline from '@mui/material/CssBaseline';
+import Divider from '@mui/material/Divider';
+import Drawer from '@mui/material/Drawer';
+import IconButton from '@mui/material/IconButton';
+import { styled, useTheme } from '@mui/material/styles';
+
+import HarvardIcon from '../assets/HarvardUniversity_Horizontal_Large_Shield_RGB.png';
+import DarkHarvardIcon from '../assets/HarvardUniversity_Horizontal_Large_Shield_Reverse_RGB.png';
+
+const drawerWidth = 340;
+
+const Main = styled('main', { shouldForwardProp: (prop) => prop !== 'open' })<{
+  open?: boolean;
+}>(({ theme, open }) => ({
+  flexGrow: 1,
+  padding: theme.spacing(0),
+  width: 0,
+  transition: theme.transitions.create('margin', {
+    easing: theme.transitions.easing.sharp,
+    duration: theme.transitions.duration.leavingScreen
+  }),
+  marginLeft: `-${drawerWidth}px`,
+  ...(open && {
+    transition: theme.transitions.create('margin', {
+      easing: theme.transitions.easing.easeOut,
+      duration: theme.transitions.duration.enteringScreen
+    }),
+    marginLeft: 0
+  })
+}));
+
+const DrawerHeader = styled('div')(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  padding: theme.spacing(0, 1),
+  // necessary for content to be below app bar
+  ...theme.mixins.toolbar,
+  justifyContent: 'flex-end'
+}));
+
+export default function PersistentDrawerLeft() {
+  const theme = useTheme();
+  const [open, setOpen] = React.useState(false);
+
+  const handleDrawerOpen = () => {
+    setOpen(true);
+  };
+
+  const handleDrawerClose = () => {
+    setOpen(false);
+  };
+  console.log('mode', theme.palette.mode);
+  return (
+    <Box sx={{ display: 'flex' }}>
+      <CssBaseline />
+      <IconButton
+        color="inherit"
+        aria-label="open drawer"
+        onClick={handleDrawerOpen}
+        edge="start"
+        sx={{
+          mb: { lg: '7rem' },
+          ml: '2px',
+          mr: 0,
+          bottom: '22rem',
+          ...(open && { display: 'none' })
+        }}
+      >
+        <MenuIcon />
+      </IconButton>
+      <Drawer
+        sx={{
+          width: drawerWidth,
+          flexShrink: 0,
+          '& .MuiDrawer-paper': {
+            width: drawerWidth,
+            boxSizing: 'border-box'
+          },
+          '& .MuiPaper-root': {
+            marginTop: '4rem'
+          }
+        }}
+        variant="persistent"
+        anchor="left"
+        open={open}
+      >
+        <DrawerHeader>
+          <IconButton onClick={handleDrawerClose}>
+            {theme.direction === 'ltr' ? (
+              <ChevronLeftIcon />
+            ) : (
+              <ChevronRightIcon />
+            )}
+          </IconButton>
+        </DrawerHeader>
+        <Divider />
+        <div style={{ padding: '1rem' }}>
+          <img
+            src={theme.palette.mode == 'dark' ? DarkHarvardIcon : HarvardIcon}
+            alt="harvard icon"
+          />
+          <h1>AI Sandbox</h1>
+          <h2>(Pilot Version)</h2>
+          <p>
+            Use of this AI Sandbox is subject to data handling practices as
+            outlined in the
+            <a href="https://policy.security.harvard.edu/">
+              {' '}
+              University's Information Security Policies
+            </a>
+            . The AI Sandbox is approived for use with Medium Risk Confidential
+            data(L3) and below. Do not enter any High Risk Confidential data (L4
+            or above). Foraddition information, review the University's
+            guidelines for the use of generative AI.
+          </p>
+        </div>
+      </Drawer>
+      <Main open={open}>
+        <DrawerHeader />
+      </Main>
+    </Box>
+  );
+}

--- a/src/chainlit/frontend/src/components/Sidebar.tsx
+++ b/src/chainlit/frontend/src/components/Sidebar.tsx
@@ -46,7 +46,7 @@ const DrawerHeader = styled('div')(({ theme }) => ({
 
 export default function PersistentDrawerLeft() {
   const theme = useTheme();
-  const [open, setOpen] = React.useState(false);
+  const [open, setOpen] = React.useState(true);
 
   const handleDrawerOpen = () => {
     setOpen(true);
@@ -55,7 +55,7 @@ export default function PersistentDrawerLeft() {
   const handleDrawerClose = () => {
     setOpen(false);
   };
-  console.log('mode', theme.palette.mode);
+
   return (
     <Box sx={{ display: 'flex' }}>
       <CssBaseline />

--- a/src/chainlit/frontend/src/components/Sidebar.tsx
+++ b/src/chainlit/frontend/src/components/Sidebar.tsx
@@ -117,7 +117,7 @@ export default function PersistentDrawerLeft() {
             </a>
             . The AI Sandbox is approived for use with Medium Risk Confidential
             data(L3) and below. Do not enter any High Risk Confidential data (L4
-            or above). Foraddition information, review the University's
+            or above). For additional information, review the University's
             guidelines for the use of generative AI.
           </p>
         </div>

--- a/src/chainlit/frontend/src/components/Sidebar.tsx
+++ b/src/chainlit/frontend/src/components/Sidebar.tsx
@@ -61,7 +61,7 @@ export default function PersistentDrawerLeft() {
       <CssBaseline />
       <IconButton
         color="inherit"
-        aria-label="open drawer"
+        aria-label="open sidebar"
         onClick={handleDrawerOpen}
         edge="start"
         sx={{
@@ -91,7 +91,7 @@ export default function PersistentDrawerLeft() {
         open={open}
       >
         <DrawerHeader>
-          <IconButton onClick={handleDrawerClose}>
+          <IconButton onClick={handleDrawerClose} aria-label="close sidebar">
             {theme.direction === 'ltr' ? (
               <ChevronLeftIcon />
             ) : (
@@ -104,6 +104,7 @@ export default function PersistentDrawerLeft() {
           <img
             src={theme.palette.mode == 'dark' ? DarkHarvardIcon : HarvardIcon}
             alt="harvard icon"
+            style={{ width: '18rem' }}
           />
           <h1>AI Sandbox</h1>
           <h2>(Pilot Version)</h2>

--- a/src/chainlit/frontend/src/components/Sidebar.tsx
+++ b/src/chainlit/frontend/src/components/Sidebar.tsx
@@ -66,7 +66,8 @@ export default function PersistentDrawerLeft() {
         onClick={handleDrawerOpen}
         edge="start"
         sx={{
-          mb: { lg: '7rem' },
+          mb: { md: '14rem', lg: '14rem' },
+          mt: { xs: '10rem' },
           ml: '2px',
           mr: 0,
           bottom: '22rem',

--- a/src/chainlit/frontend/src/components/atoms/buttons/accentButton.tsx
+++ b/src/chainlit/frontend/src/components/atoms/buttons/accentButton.tsx
@@ -8,6 +8,11 @@ export default function AccentButton({ children, ...props }: ButtonProps) {
       <Button
         color={theme.palette.mode === 'dark' ? 'inherit' : 'primary'}
         {...props}
+        sx={{
+          '&:focus, &:hover, &.Mui-active, &.Mui-focusVisible': {
+            outline: '2px solid crimson'
+          }
+        }}
       >
         {children}
       </Button>

--- a/src/chainlit/frontend/src/components/atoms/buttons/button.tsx
+++ b/src/chainlit/frontend/src/components/atoms/buttons/button.tsx
@@ -21,7 +21,8 @@ export default function RegularButton({ children, ...props }: Props) {
             theme.palette.mode === 'dark'
               ? grey[700]
               : theme.palette.primary.light,
-          '&:hover': {
+          '&:focus, &:hover, &.Mui-active, &.Mui-focusVisible': {
+            outline: '2px solid crimson',
             background: (theme) =>
               theme.palette.mode === 'dark'
                 ? grey[700]

--- a/src/chainlit/frontend/src/components/atoms/buttons/userButton/avatar.tsx
+++ b/src/chainlit/frontend/src/components/atoms/buttons/userButton/avatar.tsx
@@ -8,7 +8,7 @@ export default function UserAvatar() {
 
   if (user) {
     return (
-      <Avatar sx={{ width: 32, height: 32 }} src={user.picture || undefined} variant='square'>
+      <Avatar sx={{ width: 32, height: 32 }} src={user.picture || undefined}>
         {user.name?.[0]}
       </Avatar>
     );

--- a/src/chainlit/frontend/src/components/atoms/buttons/userButton/avatar.tsx
+++ b/src/chainlit/frontend/src/components/atoms/buttons/userButton/avatar.tsx
@@ -8,7 +8,11 @@ export default function UserAvatar() {
 
   if (user) {
     return (
-      <Avatar sx={{ width: 32, height: 32 }} src={user.picture || undefined}>
+      <Avatar
+        sx={{ width: 32, height: 32 }}
+        src={user.picture || undefined}
+        variant="square"
+      >
         {user.name?.[0]}
       </Avatar>
     );
@@ -22,7 +26,8 @@ export default function UserAvatar() {
             width: 32,
             height: 32,
             bgcolor: 'transparent',
-            color: 'inherit'
+            color: 'inherit',
+            variant: 'square'
           }}
         />
       </Box>

--- a/src/chainlit/frontend/src/components/atoms/buttons/userButton/avatar.tsx
+++ b/src/chainlit/frontend/src/components/atoms/buttons/userButton/avatar.tsx
@@ -8,7 +8,7 @@ export default function UserAvatar() {
 
   if (user) {
     return (
-      <Avatar sx={{ width: 32, height: 32 }} src={user.picture || undefined}>
+      <Avatar sx={{ width: 32, height: 32 }} src={user.picture || undefined} variant='square'>
         {user.name?.[0]}
       </Avatar>
     );

--- a/src/chainlit/frontend/src/components/atoms/buttons/userButton/index.tsx
+++ b/src/chainlit/frontend/src/components/atoms/buttons/userButton/index.tsx
@@ -24,6 +24,7 @@ export default function UserButton() {
         aria-controls={open ? 'account-menu' : undefined}
         aria-haspopup="true"
         aria-expanded={open ? 'true' : undefined}
+        aria-label="User Account Menu"
       >
         <UserAvatar />
       </IconButton>

--- a/src/chainlit/frontend/src/components/atoms/buttons/userButton/index.tsx
+++ b/src/chainlit/frontend/src/components/atoms/buttons/userButton/index.tsx
@@ -24,7 +24,7 @@ export default function UserButton() {
         aria-controls={open ? 'account-menu' : undefined}
         aria-haspopup="true"
         aria-expanded={open ? 'true' : undefined}
-        aria-label="User Account Menu"
+        aria-label="Options Menu"
       >
         <UserAvatar />
       </IconButton>

--- a/src/chainlit/frontend/src/components/atoms/buttons/userButton/menu.tsx
+++ b/src/chainlit/frontend/src/components/atoms/buttons/userButton/menu.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 
+import CloseIcon from '@mui/icons-material/Close';
 import KeyIcon from '@mui/icons-material/Key';
 import LogoutIcon from '@mui/icons-material/Logout';
 import SettingsIcon from '@mui/icons-material/Settings';
@@ -43,21 +44,35 @@ export default function UserMenu({ anchorEl, open, handleClose }: Props) {
   );
 
   const settingsItem = (
-    <MenuItem
-      key="settings"
-      onClick={() => {
-        setAppSettings((old) => ({ ...old, open: true }));
-        handleClose();
-      }}
-    >
-      <ListItemIcon>
-        <SettingsIcon fontSize="small" aria-label="Settings Menu" />
-      </ListItemIcon>
-      <ListItemText>Settings</ListItemText>
-      <Typography variant="body2" color="text.secondary">
-        S
-      </Typography>
-    </MenuItem>
+    <>
+      <MenuItem
+        key="settings"
+        onClick={() => {
+          setAppSettings((old) => ({ ...old, open: true }));
+          handleClose();
+        }}
+      >
+        <ListItemIcon>
+          <SettingsIcon fontSize="small" aria-label="Settings Menu" />
+        </ListItemIcon>
+        <ListItemText>Settings</ListItemText>
+      </MenuItem>
+      <MenuItem
+        key="close"
+        onClick={() => {
+          handleClose();
+        }}
+      >
+        <ListItemIcon>
+          <CloseIcon
+            style={{ paddingLeft: 0 }}
+            fontSize="small"
+            aria-label="close settings"
+          />
+        </ListItemIcon>
+        <ListItemText>Close</ListItemText>
+      </MenuItem>
+    </>
   );
 
   const apiKeysItem = requiredKeys && (

--- a/src/chainlit/frontend/src/components/atoms/buttons/userButton/menu.tsx
+++ b/src/chainlit/frontend/src/components/atoms/buttons/userButton/menu.tsx
@@ -51,7 +51,7 @@ export default function UserMenu({ anchorEl, open, handleClose }: Props) {
       }}
     >
       <ListItemIcon>
-        <SettingsIcon fontSize="small" />
+        <SettingsIcon fontSize="small" aria-label="Settings Menu" />
       </ListItemIcon>
       <ListItemText>Settings</ListItemText>
       <Typography variant="body2" color="text.secondary">

--- a/src/chainlit/frontend/src/components/atoms/element/avatar.tsx
+++ b/src/chainlit/frontend/src/components/atoms/element/avatar.tsx
@@ -9,11 +9,16 @@ interface Props {
 
 export default function AvatarElement({ element, author }: Props) {
   const src = element.url || URL.createObjectURL(new Blob([element.content!]));
+  const alt = element.alt;
   const className = `message-avatar`;
   return (
     <Tooltip title={author}>
       <span className={className}>
-        <Avatar sx={{ width: 38, height: 38, mt: '-4px' }} src={src} />
+        <Avatar
+          sx={{ width: 38, height: 38, mt: '-4px' }}
+          alt={alt}
+          src={src}
+        />
       </span>
     </Tooltip>
   );

--- a/src/chainlit/frontend/src/components/atoms/element/avatar.tsx
+++ b/src/chainlit/frontend/src/components/atoms/element/avatar.tsx
@@ -18,6 +18,7 @@ export default function AvatarElement({ element, author }: Props) {
           sx={{ width: 38, height: 38, mt: '-4px' }}
           alt={alt}
           src={src}
+          variant="square"
         />
       </span>
     </Tooltip>

--- a/src/chainlit/frontend/src/components/atoms/logo.tsx
+++ b/src/chainlit/frontend/src/components/atoms/logo.tsx
@@ -13,5 +13,5 @@ interface Props {
 export const Logo = ({ width, style }: Props) => {
   const { theme } = useRecoilValue(settingsState);
   const src = theme === 'light' ? LogoLight : LogoDark;
-  return <img src={src} style={style} width={width || 40} />;
+  return <img src={src} style={style} width={width || 40} alt="Chainlit" />;
 };

--- a/src/chainlit/frontend/src/components/atoms/switch.tsx
+++ b/src/chainlit/frontend/src/components/atoms/switch.tsx
@@ -55,13 +55,21 @@ const StyledSwitch = styled((props: MSwitchProps) => (
   const isDarkMode = theme.palette.mode === 'dark';
 
   return {
+    '&:focus, &:hover, &.Mui-active, &.Mui-focusVisible': {
+      outline: '2px solid crimson',
+      borderRadius: 26 / 2
+    },
     width: 40,
     height: 24,
     padding: 0,
+    overflow: 'visible',
     '& .MuiSwitch-switchBase': {
       margin: 0,
       padding: '4px',
       transitionDuration: '300ms',
+      '&:focus, &:hover, &.Mui-active, &.Mui-focusVisible': {
+        outline: '2px solid crimson'
+      },
       '&.Mui-checked': {
         transform: 'translateX(16px)',
         color: '#fff',

--- a/src/chainlit/frontend/src/components/molecules/inputLabel.tsx
+++ b/src/chainlit/frontend/src/components/molecules/inputLabel.tsx
@@ -24,7 +24,7 @@ export default function inputLabel({
           sx={{
             fontWeight: 600,
             fontSize: '12px',
-            color: 'grey.500'
+            color: 'grey.800'
           }}
         >
           {label}

--- a/src/chainlit/frontend/src/components/molecules/newChatButton.tsx
+++ b/src/chainlit/frontend/src/components/molecules/newChatButton.tsx
@@ -40,6 +40,11 @@ export default function NewChatButton() {
         variant="outlined"
         onClick={handleClickOpen}
         startIcon={<AddIcon />}
+        sx={{
+          '&:focus, &:hover, &.Mui-active, &.Mui-focusVisible': {
+            outline: '2px solid crimson'
+          }
+        }}
       >
         New Chat
       </AccentButton>

--- a/src/chainlit/frontend/src/components/molecules/settingsModal.tsx
+++ b/src/chainlit/frontend/src/components/molecules/settingsModal.tsx
@@ -58,13 +58,13 @@ export default function SettingsModal() {
             <ListItemText id="list-expand-all" primary="Expand Messages" />
             <Box>
               <Switch
-                id="switch-expand-all"
+                id="switch-expand-all-messages"
                 onChange={() =>
                   setSettings((old) => ({ ...old, expandAll: !old.expandAll }))
                 }
                 checked={settings.expandAll}
                 inputProps={{
-                  'aria-labelledby': 'switch-expand-all'
+                  'aria-label': 'switch expand all messages'
                 }}
               />
             </Box>

--- a/src/chainlit/frontend/src/components/molecules/settingsModal.tsx
+++ b/src/chainlit/frontend/src/components/molecules/settingsModal.tsx
@@ -64,7 +64,7 @@ export default function SettingsModal() {
                 }
                 checked={settings.expandAll}
                 inputProps={{
-                  'aria-label': 'switch expand all messages'
+                  'aria-label': 'Expand Messages'
                 }}
               />
             </Box>

--- a/src/chainlit/frontend/src/components/molecules/settingsModal.tsx
+++ b/src/chainlit/frontend/src/components/molecules/settingsModal.tsx
@@ -1,5 +1,6 @@
 import { useRecoilState } from 'recoil';
 
+import CloseIcon from '@mui/icons-material/Close';
 import DarkModeOutlined from '@mui/icons-material/DarkModeOutlined';
 import EmojiObjectsIcon from '@mui/icons-material/EmojiObjects';
 import ExpandIcon from '@mui/icons-material/Expand';
@@ -7,6 +8,7 @@ import {
   Box,
   Dialog,
   DialogContent,
+  IconButton,
   List,
   ListItem,
   ListItemIcon,
@@ -20,11 +22,11 @@ import { settingsState } from 'state/settings';
 
 export default function SettingsModal() {
   const [settings, setSettings] = useRecoilState(settingsState);
-
+  const handleClose = () => setSettings((old) => ({ ...old, open: false }));
   return (
     <Dialog
       open={settings.open}
-      onClose={() => setSettings((old) => ({ ...old, open: false }))}
+      onClose={handleClose}
       id="settings-dialog"
       PaperProps={{
         sx: {
@@ -35,7 +37,19 @@ export default function SettingsModal() {
       <DialogContent>
         <List
           sx={{ width: '100%', maxWidth: 360 }}
-          subheader={<ListSubheader>Settings</ListSubheader>}
+          subheader={
+            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+              <ListSubheader>Settings</ListSubheader>
+              <IconButton
+                edge={false}
+                sx={{ ml: 'auto' }}
+                onClick={handleClose}
+                aria-label="close settings modal"
+              >
+                <CloseIcon />
+              </IconButton>
+            </div>
+          }
         >
           <ListItem sx={{ display: 'flex', gap: 2 }}>
             <ListItemIcon>

--- a/src/chainlit/frontend/src/components/organisms/chat/index.tsx
+++ b/src/chainlit/frontend/src/components/organisms/chat/index.tsx
@@ -104,7 +104,18 @@ const Chat = () => {
   const tasklist = tasklistElements.at(-1);
 
   return (
-    <Box display="flex" width="100%" height="0" flexGrow={1}>
+    <Box
+      sx={{
+        width: {
+          xs: '80%',
+          md: '100%',
+          lg: '100%'
+        },
+        display: 'flex',
+        height: 0
+      }}
+      flexGrow={1}
+    >
       <Head title="Chat" description="Chat" />
       <Sidebar />
       <Playground />

--- a/src/chainlit/frontend/src/components/organisms/chat/index.tsx
+++ b/src/chainlit/frontend/src/components/organisms/chat/index.tsx
@@ -5,6 +5,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { Alert, Box } from '@mui/material';
 
 import Head from 'components/Head';
+import Sidebar from 'components/Sidebar';
 import SideView from 'components/atoms/element/sideView';
 import ErrorBoundary from 'components/atoms/errorBoundary';
 import TaskList from 'components/molecules/tasklist';
@@ -105,6 +106,7 @@ const Chat = () => {
   return (
     <Box display="flex" width="100%" height="0" flexGrow={1}>
       <Head title="Chat" description="Chat" />
+      <Sidebar />
       <Playground />
       <ChatSettingsModal />
       <TaskList tasklist={tasklist} isMobile={false} />

--- a/src/chainlit/frontend/src/components/organisms/chat/index.tsx
+++ b/src/chainlit/frontend/src/components/organisms/chat/index.tsx
@@ -4,6 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { Alert, Box } from '@mui/material';
 
+import Head from 'components/Head';
 import SideView from 'components/atoms/element/sideView';
 import ErrorBoundary from 'components/atoms/errorBoundary';
 import TaskList from 'components/molecules/tasklist';
@@ -103,6 +104,7 @@ const Chat = () => {
 
   return (
     <Box display="flex" width="100%" height="0" flexGrow={1}>
+      <Head title="Chat" description="Chat" />
       <Playground />
       <ChatSettingsModal />
       <TaskList tasklist={tasklist} isMobile={false} />

--- a/src/chainlit/frontend/src/components/organisms/chat/inputBox/input.tsx
+++ b/src/chainlit/frontend/src/components/organisms/chat/inputBox/input.tsx
@@ -99,8 +99,9 @@ const Input = ({ onSubmit, onReply }: Props) => {
           disabled={disabled}
           color="inherit"
           onClick={() => setChatSettings((old) => ({ ...old, open: true }))}
+          aria-label="Settings Panel"
         >
-          <TuneIcon aria-label="Filter Menu" />
+          <TuneIcon />
         </IconButton>
       )}
       <HistoryButton onClick={onHistoryClick} />

--- a/src/chainlit/frontend/src/components/organisms/chat/inputBox/input.tsx
+++ b/src/chainlit/frontend/src/components/organisms/chat/inputBox/input.tsx
@@ -100,7 +100,7 @@ const Input = ({ onSubmit, onReply }: Props) => {
           color="inherit"
           onClick={() => setChatSettings((old) => ({ ...old, open: true }))}
         >
-          <TuneIcon />
+          <TuneIcon aria-label="Filter Menu" />
         </IconButton>
       )}
       <HistoryButton onClick={onHistoryClick} />
@@ -109,7 +109,7 @@ const Input = ({ onSubmit, onReply }: Props) => {
 
   const endAdornment = (
     <IconButton disabled={disabled} color="inherit" onClick={() => submit()}>
-      <SendIcon />
+      <SendIcon aria-label="Send Message" />
     </IconButton>
   );
 

--- a/src/chainlit/frontend/src/components/organisms/chat/inputBox/waterMark.tsx
+++ b/src/chainlit/frontend/src/components/organisms/chat/inputBox/waterMark.tsx
@@ -6,7 +6,7 @@ export default function WaterMark() {
   return (
     <Stack mx="auto">
       <a
-        href="https://github.com/Chainlit/chainlit"
+        href="https://huit.harvard.edu"
         target="_blank"
         style={{
           display: 'flex',
@@ -15,12 +15,8 @@ export default function WaterMark() {
         }}
       >
         <Typography fontSize="12px" color="text.secondary">
-          Built with
+          Powered by HUIT
         </Typography>
-        <Logo
-          width={65}
-          style={{ filter: 'grayscale(1)', marginLeft: '4px' }}
-        />
       </a>
     </Stack>
   );

--- a/src/chainlit/frontend/src/components/organisms/chat/inputBox/waterMark.tsx
+++ b/src/chainlit/frontend/src/components/organisms/chat/inputBox/waterMark.tsx
@@ -13,6 +13,7 @@ export default function WaterMark() {
           alignItems: 'center',
           textDecoration: 'none'
         }}
+        aria-label="Built with link"
       >
         <Typography fontSize="12px" color="text.secondary">
           Built with

--- a/src/chainlit/frontend/src/components/organisms/chat/settings.tsx
+++ b/src/chainlit/frontend/src/components/organisms/chat/settings.tsx
@@ -64,7 +64,7 @@ export default function ChatSettingsModal() {
         }
       }}
     >
-      <DialogTitle id="alert-dialog-title">{'Settings panel'}</DialogTitle>
+      <DialogTitle id="alert-dialog-title">{'Large Language Model Settings'}</DialogTitle>
       <DialogContent>
         <Box
           sx={{

--- a/src/chainlit/frontend/src/components/organisms/dataset/deleteConversationButton.tsx
+++ b/src/chainlit/frontend/src/components/organisms/dataset/deleteConversationButton.tsx
@@ -57,6 +57,7 @@ export default function DeleteConversationButton({
         size="small"
         color="error"
         onClick={handleClickOpen}
+        aria-label="delete conversation"
       >
         <DeleteOutline />
       </IconButton>

--- a/src/chainlit/frontend/src/components/organisms/dataset/deleteConversationButton.tsx
+++ b/src/chainlit/frontend/src/components/organisms/dataset/deleteConversationButton.tsx
@@ -77,7 +77,7 @@ export default function DeleteConversationButton({
           </DialogTitle>
           <DialogContent>
             <DialogContentText id="alert-dialog-description">
-              This will delete the conversation as well as it's messages and
+              This will delete the conversation as well as its messages and
               elements.
             </DialogContentText>
           </DialogContent>

--- a/src/chainlit/frontend/src/components/organisms/dataset/filters/SearchBar.tsx
+++ b/src/chainlit/frontend/src/components/organisms/dataset/filters/SearchBar.tsx
@@ -83,7 +83,7 @@ export default function SearchBar() {
         onChange={(e) => _onChange(e.target.value)}
       />
       <SearchIconWrapper>
-        <IconButton onClick={clear}>
+        <IconButton onClick={clear} aria-label="clear searchbar">
           <CloseIcon />
         </IconButton>
       </SearchIconWrapper>

--- a/src/chainlit/frontend/src/components/organisms/dataset/openConversationButton.tsx
+++ b/src/chainlit/frontend/src/components/organisms/dataset/openConversationButton.tsx
@@ -16,7 +16,7 @@ export default function OpenConversationButton({ conversationId }: Props) {
       size="small"
       color="primary"
     >
-      <VisibilityIcon aria-label="view conversation" />
+      <VisibilityIcon aria-label={`view conversation ${conversationId}`} />
     </IconButton>
   );
 }

--- a/src/chainlit/frontend/src/components/organisms/dataset/openConversationButton.tsx
+++ b/src/chainlit/frontend/src/components/organisms/dataset/openConversationButton.tsx
@@ -16,7 +16,7 @@ export default function OpenConversationButton({ conversationId }: Props) {
       size="small"
       color="primary"
     >
-      <VisibilityIcon aria-label={`view conversation ${conversationId}`} />
+      <VisibilityIcon aria-label="view conversation" />
     </IconButton>
   );
 }

--- a/src/chainlit/frontend/src/components/organisms/dataset/openConversationButton.tsx
+++ b/src/chainlit/frontend/src/components/organisms/dataset/openConversationButton.tsx
@@ -16,7 +16,7 @@ export default function OpenConversationButton({ conversationId }: Props) {
       size="small"
       color="primary"
     >
-      <VisibilityIcon />
+      <VisibilityIcon aria-label="view conversation" />
     </IconButton>
   );
 }

--- a/src/chainlit/frontend/src/components/organisms/header.tsx
+++ b/src/chainlit/frontend/src/components/organisms/header.tsx
@@ -83,6 +83,10 @@ function Nav({ hasDb, hasReadme }: NavProps) {
     tabs.push({ to: '/readme', label: 'Readme' });
   }
 
+  tabs.push({ to: 'https://huit.harvard.edu/ai-sandbox', label: 'About' });
+
+  tabs.push({ to: 'https://huit.harvard.edu/', label: 'Help' });
+
   const nav = (
     <Stack direction={matches ? 'column' : 'row'} spacing={1}>
       {tabs.map((t) => {

--- a/src/chainlit/frontend/src/components/organisms/header.tsx
+++ b/src/chainlit/frontend/src/components/organisms/header.tsx
@@ -1,5 +1,6 @@
+import { grey } from 'palette';
 import { useRef, useState } from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 
 import MenuIcon from '@mui/icons-material/Menu';
@@ -9,10 +10,12 @@ import {
   Button,
   IconButton,
   Menu,
+  MenuItem,
   Stack,
   Toolbar,
   useTheme
 } from '@mui/material';
+import { Theme } from '@mui/material';
 import useMediaQuery from '@mui/material/useMediaQuery';
 
 import RegularButton from 'components/atoms/buttons/button';
@@ -27,6 +30,11 @@ interface INavItem {
   label: string;
 }
 
+interface IMenuItem {
+  to: string;
+  label: string;
+  tabIndex: number;
+}
 function ActiveNavItem({ to, label }: INavItem) {
   return (
     <RegularButton component={Link} to={to} key={to}>
@@ -35,25 +43,51 @@ function ActiveNavItem({ to, label }: INavItem) {
   );
 }
 
+const styleOverrides = {
+  inactive: {
+    textTransform: 'none',
+    color: 'text.secondary',
+    '&:focus, &:hover, &.Mui-active, &.Mui-focusVisible': {
+      outline: '2px solid crimson',
+      background: 'transparent'
+    }
+  },
+  active: {
+    textTransform: 'none',
+    color: (theme: Theme) =>
+      theme.palette.mode === 'dark'
+        ? 'text.primary'
+        : theme.palette.primary.main,
+    background: (theme: Theme) =>
+      theme.palette.mode === 'dark' ? grey[700] : theme.palette.primary.light,
+    '&:focus, &:hover, &.Mui-active, &.Mui-focusVisible': {
+      outline: '2px solid crimson',
+      background: (theme: Theme) =>
+        theme.palette.mode === 'dark' ? grey[700] : theme.palette.primary.light
+    }
+  }
+};
+
 function NavItem({ to, label }: INavItem) {
   return (
-    <Button
-      component={Link}
-      to={to}
-      key={to}
-      sx={{
-        textTransform: 'none',
-        color: 'text.secondary',
-        '&:focus, &:hover, &.Mui-active, &.Mui-focusVisible': {
-          outline: '2px solid crimson',
-          background: 'transparent'
-        }
-      }}
-    >
+    <Button component={Link} to={to} key={to} sx={styleOverrides.inactive}>
       {label}
     </Button>
   );
 }
+
+const ActiveMenuItem = ({ to, label, tabIndex }: IMenuItem) => (
+  <MenuItem
+    component={Link}
+    key={to}
+    to={to}
+    tabIndex={tabIndex}
+    autoFocus={true}
+    sx={styleOverrides.active}
+  >
+    {label}
+  </MenuItem>
+);
 
 interface NavProps {
   hasDb?: boolean;
@@ -131,7 +165,22 @@ function Nav({ hasDb, hasReadme }: NavProps) {
           anchorOrigin={{ vertical: 'top', horizontal: 'left' }}
           transformOrigin={{ vertical: 'bottom', horizontal: 'left' }}
         >
-          {nav}
+          {tabs.map((t, index) => {
+            const active = location.pathname === t.to;
+            return active ? (
+              <ActiveMenuItem {...t} tabIndex={index} />
+            ) : (
+              <MenuItem
+                sx={styleOverrides.inactive}
+                key={t.to}
+                component={Link}
+                to={t.to}
+                tabIndex={index}
+              >
+                {t.label}
+              </MenuItem>
+            );
+          })}
         </Menu>
       </>
     );

--- a/src/chainlit/frontend/src/components/organisms/header.tsx
+++ b/src/chainlit/frontend/src/components/organisms/header.tsx
@@ -44,7 +44,8 @@ function NavItem({ to, label }: INavItem) {
       sx={{
         textTransform: 'none',
         color: 'text.secondary',
-        '&:hover': {
+        '&:focus, &:hover, &.Mui-active, &.Mui-focusVisible': {
+          outline: '2px solid crimson',
           background: 'transparent'
         }
       }}

--- a/src/chainlit/frontend/src/components/organisms/header.tsx
+++ b/src/chainlit/frontend/src/components/organisms/header.tsx
@@ -1,6 +1,6 @@
 import { grey } from 'palette';
 import { useRef, useState } from 'react';
-import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 
 import MenuIcon from '@mui/icons-material/Menu';

--- a/src/chainlit/frontend/src/components/organisms/inputs/inputStateHandler.tsx
+++ b/src/chainlit/frontend/src/components/organisms/inputs/inputStateHandler.tsx
@@ -18,7 +18,8 @@ export default function InputStateHandler(
     id,
     label,
     notificationsCount,
-    tooltip
+    tooltip,
+    type
   } = props;
 
   return (
@@ -31,7 +32,11 @@ export default function InputStateHandler(
           notificationsCount={notificationsCount}
         />
       ) : null}
-      <FormControl error={hasError} fullWidth>
+      <FormControl
+        error={hasError}
+        fullWidth
+        aria-label={label && type ? `${label} ${type}` : label || type}
+      >
         {children}
         {description ? <FormHelperText>{description}</FormHelperText> : null}
       </FormControl>

--- a/src/chainlit/frontend/src/components/organisms/inputs/inputStateHandler.tsx
+++ b/src/chainlit/frontend/src/components/organisms/inputs/inputStateHandler.tsx
@@ -18,8 +18,7 @@ export default function InputStateHandler(
     id,
     label,
     notificationsCount,
-    tooltip,
-    inputType
+    tooltip
   } = props;
 
   return (
@@ -32,13 +31,7 @@ export default function InputStateHandler(
           notificationsCount={notificationsCount}
         />
       ) : null}
-      <FormControl
-        error={hasError}
-        fullWidth
-        aria-label={
-          label && inputType ? `${label} ${inputType}` : label || inputType
-        }
-      >
+      <FormControl error={hasError} fullWidth aria-label={label}>
         {children}
         {description ? <FormHelperText>{description}</FormHelperText> : null}
       </FormControl>

--- a/src/chainlit/frontend/src/components/organisms/inputs/inputStateHandler.tsx
+++ b/src/chainlit/frontend/src/components/organisms/inputs/inputStateHandler.tsx
@@ -19,7 +19,7 @@ export default function InputStateHandler(
     label,
     notificationsCount,
     tooltip,
-    type
+    inputType
   } = props;
 
   return (
@@ -35,7 +35,9 @@ export default function InputStateHandler(
       <FormControl
         error={hasError}
         fullWidth
-        aria-label={label && type ? `${label} ${type}` : label || type}
+        aria-label={
+          label && inputType ? `${label} ${inputType}` : label || inputType
+        }
       >
         {children}
         {description ? <FormHelperText>{description}</FormHelperText> : null}

--- a/src/chainlit/frontend/src/components/organisms/inputs/selectInput.tsx
+++ b/src/chainlit/frontend/src/components/organisms/inputs/selectInput.tsx
@@ -99,6 +99,12 @@ export default function SelectInput({
         onChange={onChange}
         size={size}
         disabled={disabled}
+        // check if value is a string so we dont create aria-label with numbers
+        aria-label={
+          (typeof value == 'number'
+            ? items?.find((item) => item.value === value)?.label
+            : value) + ' list box'
+        }
         renderValue={() =>
           (renderLabel && renderLabel()) ||
           `${items?.find((item) => item.value === value)?.label}`

--- a/src/chainlit/frontend/src/components/organisms/inputs/selectInput.tsx
+++ b/src/chainlit/frontend/src/components/organisms/inputs/selectInput.tsx
@@ -99,12 +99,7 @@ export default function SelectInput({
         onChange={onChange}
         size={size}
         disabled={disabled}
-        // check if value is a string so we dont create aria-label with numbers
-        aria-label={
-          (typeof value == 'number'
-            ? items?.find((item) => item.value === value)?.label
-            : value) + ' list box'
-        }
+        aria-label={label}
         renderValue={() =>
           (renderLabel && renderLabel()) ||
           `${items?.find((item) => item.value === value)?.label}`

--- a/src/chainlit/frontend/src/components/organisms/inputs/selectInput.tsx
+++ b/src/chainlit/frontend/src/components/organisms/inputs/selectInput.tsx
@@ -45,6 +45,7 @@ export const renderMenuItem = ({
   <MenuItem
     value={item.value}
     key={`select-${index}`}
+    aria-label={item.label}
     sx={{
       display: 'flex',
       justifyContent: 'space-between',

--- a/src/chainlit/frontend/src/components/organisms/playground/index.tsx
+++ b/src/chainlit/frontend/src/components/organisms/playground/index.tsx
@@ -153,7 +153,7 @@ export default function Playground() {
             onClick={toggleDrawer}
             sx={{ mr: '4px' }}
           >
-            <SettingsIcon />
+            <SettingsIcon aria-label="Settings Menu" />
           </IconButton>
           <IconButton edge="end" id="close-playground" onClick={handleClose}>
             <CloseIcon />

--- a/src/chainlit/frontend/src/components/organisms/slider.tsx
+++ b/src/chainlit/frontend/src/components/organisms/slider.tsx
@@ -25,12 +25,13 @@ const _Slider = ({
       label={label}
       tooltip={tooltip}
       notificationsCount={sliderProps.value?.toString()}
+      type="slider"
     >
       <StyledSlider
         {...sliderProps}
         id={id}
         name={id}
-        aria-label={label + ' slider'}
+        aria-label={label + ' slider thumb'}
       />
     </InputStateHandler>
   );
@@ -47,13 +48,18 @@ const StyledSlider = styled(Slider)(({ theme }) => {
       border: 'none',
       color: grey[500]
     },
+    '& .MuiSlider-root, &:focus, &:hover, &.Mui-focusVisible': {
+      // boxShadow: 'inherit'
+      outline: '2px solid crimson'
+    },
     '& .MuiSlider-thumb': {
       height: 15,
       width: 15,
       backgroundColor: isLightMode ? grey[600] : 'white',
       border: `4px solid ${isLightMode ? grey[300] : grey[800]}`,
-      '&:focus, &:hover, &.Mui-active, &.Mui-focusVisible': {
-        boxShadow: 'inherit'
+      '&:focus, &:hover, &.Mui-active, &.Mui-focusVisible, & .MuiSlider-root': {
+        boxShadow: 'inherit',
+        outline: '2px solid crimson'
       },
       '&:before': {
         display: 'none'

--- a/src/chainlit/frontend/src/components/organisms/slider.tsx
+++ b/src/chainlit/frontend/src/components/organisms/slider.tsx
@@ -25,14 +25,8 @@ const _Slider = ({
       label={label}
       tooltip={tooltip}
       notificationsCount={sliderProps.value?.toString()}
-      inputType="slider"
     >
-      <StyledSlider
-        {...sliderProps}
-        id={id}
-        name={id}
-        aria-label={label + ' slider thumb'}
-      />
+      <StyledSlider {...sliderProps} id={id} name={id} aria-label={label} />
     </InputStateHandler>
   );
 };

--- a/src/chainlit/frontend/src/components/organisms/slider.tsx
+++ b/src/chainlit/frontend/src/components/organisms/slider.tsx
@@ -26,7 +26,12 @@ const _Slider = ({
       tooltip={tooltip}
       notificationsCount={sliderProps.value?.toString()}
     >
-      <StyledSlider {...sliderProps} id={id} name={id} aria-label={label} />
+      <StyledSlider
+        {...sliderProps}
+        id={id}
+        name={id}
+        aria-label={label + ' slider'}
+      />
     </InputStateHandler>
   );
 };

--- a/src/chainlit/frontend/src/components/organisms/slider.tsx
+++ b/src/chainlit/frontend/src/components/organisms/slider.tsx
@@ -25,7 +25,7 @@ const _Slider = ({
       label={label}
       tooltip={tooltip}
       notificationsCount={sliderProps.value?.toString()}
-      type="slider"
+      inputType="slider"
     >
       <StyledSlider
         {...sliderProps}

--- a/src/chainlit/frontend/src/components/organisms/slider.tsx
+++ b/src/chainlit/frontend/src/components/organisms/slider.tsx
@@ -26,7 +26,7 @@ const _Slider = ({
       tooltip={tooltip}
       notificationsCount={sliderProps.value?.toString()}
     >
-      <StyledSlider {...sliderProps} id={id} name={id} />
+      <StyledSlider {...sliderProps} id={id} name={id} aria-label={label} />
     </InputStateHandler>
   );
 };

--- a/src/chainlit/frontend/src/pages/Dataset.tsx
+++ b/src/chainlit/frontend/src/pages/Dataset.tsx
@@ -6,7 +6,7 @@ import Conversation from 'components/organisms/dataset';
 export default function Dataset() {
   return (
     <>
-      <Head title="dataset" description="dataset" />
+      <Head title="History" description="History" />
       <Page>
         <Conversation />
       </Page>

--- a/src/chainlit/frontend/src/pages/Dataset.tsx
+++ b/src/chainlit/frontend/src/pages/Dataset.tsx
@@ -5,9 +5,11 @@ import Conversation from 'components/organisms/dataset';
 
 export default function Dataset() {
   return (
-    <Page>
-      <Head title="dataset" desccription="dataset" />
-      <Conversation />
-    </Page>
+    <>
+      <Head title="dataset" description="dataset" />
+      <Page>
+        <Conversation />
+      </Page>
+    </>
   );
 }

--- a/src/chainlit/frontend/src/pages/Dataset.tsx
+++ b/src/chainlit/frontend/src/pages/Dataset.tsx
@@ -1,10 +1,12 @@
 import Page from 'pages/Page';
 
+import Head from 'components/Head';
 import Conversation from 'components/organisms/dataset';
 
 export default function Dataset() {
   return (
     <Page>
+      <Head title="dataset" desccription="dataset" />
       <Conversation />
     </Page>
   );

--- a/src/chainlit/frontend/src/pages/Page.tsx
+++ b/src/chainlit/frontend/src/pages/Page.tsx
@@ -51,7 +51,11 @@ const Page = ({ children }: Props) => {
       sx={{
         display: 'flex',
         flexDirection: 'column',
-        width: '100%'
+        width: '100%',
+        overflow: {
+          xs: 'hidden',
+          sm: 'hidden'
+        }
       }}
     >
       <Header />

--- a/src/chainlit/frontend/src/pages/Readme.tsx
+++ b/src/chainlit/frontend/src/pages/Readme.tsx
@@ -2,11 +2,13 @@ import Page from 'pages/Page';
 
 import { Box } from '@mui/material';
 
+import Head from 'components/Head';
 import WelcomeScreen from 'components/organisms/chat/welcomeScreen';
 
 export default function Readme() {
   return (
     <Page>
+      <Head title="Readme" description="Readme" />
       <Box sx={{ px: 2 }}>
         <WelcomeScreen />
       </Box>

--- a/src/chainlit/frontend/src/pages/Readme.tsx
+++ b/src/chainlit/frontend/src/pages/Readme.tsx
@@ -7,11 +7,13 @@ import WelcomeScreen from 'components/organisms/chat/welcomeScreen';
 
 export default function Readme() {
   return (
-    <Page>
+    <>
       <Head title="Readme" description="Readme" />
-      <Box sx={{ px: 2 }}>
-        <WelcomeScreen />
-      </Box>
-    </Page>
+      <Page>
+        <Box sx={{ px: 2 }}>
+          <WelcomeScreen />
+        </Box>
+      </Page>
+    </>
   );
 }

--- a/src/chainlit/frontend/src/state/element.ts
+++ b/src/chainlit/frontend/src/state/element.ts
@@ -27,6 +27,7 @@ interface TElement<T> {
   conversationId?: string;
   forIds?: string[];
   url?: string;
+  alt?: string;
 }
 
 interface TMessageElement<T> extends TElement<T> {

--- a/src/chainlit/frontend/src/types/Input.ts
+++ b/src/chainlit/frontend/src/types/Input.ts
@@ -8,6 +8,7 @@ interface IInput {
   notificationsCount?: number | string;
   size?: 'small' | 'medium';
   tooltip?: string;
+  type?: string;
 }
 
 export type { IInput };

--- a/src/chainlit/frontend/src/types/Input.ts
+++ b/src/chainlit/frontend/src/types/Input.ts
@@ -8,7 +8,7 @@ interface IInput {
   notificationsCount?: number | string;
   size?: 'small' | 'medium';
   tooltip?: string;
-  type?: string;
+  inputType?: string;
 }
 
 export type { IInput };

--- a/src/chainlit/frontend/src/types/Input.ts
+++ b/src/chainlit/frontend/src/types/Input.ts
@@ -8,7 +8,6 @@ interface IInput {
   notificationsCount?: number | string;
   size?: 'small' | 'medium';
   tooltip?: string;
-  inputType?: string;
 }
 
 export type { IInput };

--- a/src/chainlit/logger.py
+++ b/src/chainlit/logger.py
@@ -4,7 +4,7 @@ import sys
 logging.basicConfig(
     level=logging.INFO,
     stream=sys.stdout,
-    format="%(asctime)s - %(message)s",
+    format="%(asctime)s %(module)s:%(lineno)d - %(message)s",
     datefmt="%Y-%m-%d %H:%M:%S",
 )
 

--- a/src/chainlit/server.py
+++ b/src/chainlit/server.py
@@ -55,7 +55,7 @@ async def lifespan(app: FastAPI):
         await asyncio.sleep(1)
         webbrowser.open(url)
 
-    if config.project.database == "local":
+    if config.project.database in ["local", "custom"]:
         from prisma import Client, register  # type: ignore[attr-defined]
 
         client = Client()
@@ -103,7 +103,7 @@ async def lifespan(app: FastAPI):
     try:
         yield
     finally:
-        if config.project.database == "local":
+        if config.project.database in ["local", "custom"]:
             await client.disconnect()
         if watch_task:
             try:

--- a/src/chainlit/socket.py
+++ b/src/chainlit/socket.py
@@ -130,7 +130,9 @@ async def connection_successful(sid):
         "local",
         "custom",
     ]:
-        await context.session.db_client.create_user(session.auth_client.user_infos)
+        await context.session.db_client.create_user(
+            context.session.auth_client.user_infos
+        )
 
     if config.code.on_chat_start:
         """Call the on_chat_start function provided by the developer."""

--- a/src/chainlit/socket.py
+++ b/src/chainlit/socket.py
@@ -126,9 +126,7 @@ async def connection_successful(sid):
     if context.session.restored:
         return
 
-    if isinstance(
-        context.session.auth_client, CloudAuthClient
-    ) and config.project.database in [
+    if config.project.database in [
         "local",
         "custom",
     ]:


### PR DESCRIPTION
This PR contains changes to make Chainlit work with our custom OIDC auth client. This also makes some changes to the way that the `custom` db client is handled, treating it similarly to the `local` db client. Our `cusom` db client is essentially a flavor of `local` with data stored in a `sqlite` db file. 

* Don't require the CloudAuthClient to be used in order to call db_client.create_user()
* Change User.id to String (default uuid) 
* Allow the default `schema.prisma` file to be overridden either by setting a `SCHEMA_PATH` environment variable or by placing a `schema.prisma` file in the `.chainlit` config directory.
* Make `init_local_db()` and `migrate_local_db()` operate on `custom` db type as well. 

This PR also includes changes that were merged in from the `add-helmet` branch (PR #2). 