### PR TITLE
add helmet to chat, readme, and dataset components

### DIFF
--- a/src/chainlit/frontend/index.html
+++ b/src/chainlit/frontend/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta data-react-helmet="true" />
     <!-- TAGS INJECTION PLACEHOLDER -->
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/src/chainlit/frontend/package.json
+++ b/src/chainlit/frontend/package.json
@@ -56,6 +56,7 @@
     "@types/node": "^20.0.0",
     "@types/react": "^18.0.27",
     "@types/react-dom": "^18.0.10",
+    "@types/react-helmet": "^6.1.6",
     "@types/react-resizable": "^3.0.4",
     "@types/react-syntax-highlighter": "^15.5.6",
     "@types/react-window-infinite-loader": "^1.0.6",

--- a/src/chainlit/frontend/package.json
+++ b/src/chainlit/frontend/package.json
@@ -26,6 +26,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-dropzone": "^14.2.3",
+    "react-helmet": "^6.1.0",
     "react-hot-toast": "^2.4.0",
     "react-hotkeys-hook": "^4.4.0",
     "react-markdown": "^8.0.6",
@@ -45,7 +46,6 @@
     "yup": "^1.0.2"
   },
   "devDependencies": {
-    "@types/uuid": "^9.0.2",
     "@babel/preset-env": "^7.22.5",
     "@babel/preset-react": "^7.22.5",
     "@babel/preset-typescript": "^7.22.5",
@@ -59,6 +59,7 @@
     "@types/react-resizable": "^3.0.4",
     "@types/react-syntax-highlighter": "^15.5.6",
     "@types/react-window-infinite-loader": "^1.0.6",
+    "@types/uuid": "^9.0.2",
     "@typescript-eslint/eslint-plugin": "^5.59.2",
     "@typescript-eslint/parser": "^5.59.2",
     "@vitejs/plugin-react": "^4.0.1",

--- a/src/chainlit/frontend/pnpm-lock.yaml
+++ b/src/chainlit/frontend/pnpm-lock.yaml
@@ -44,6 +44,9 @@ dependencies:
   react-dropzone:
     specifier: ^14.2.3
     version: 14.2.3(react@18.2.0)
+  react-helmet:
+    specifier: ^6.1.0
+    version: 6.1.0(react@18.2.0)
   react-hot-toast:
     specifier: ^2.4.0
     version: 2.4.0(csstype@3.1.2)(react-dom@18.2.0)(react@18.2.0)
@@ -5064,6 +5067,22 @@ packages:
     resolution: {integrity: sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==}
     dev: false
 
+  /react-fast-compare@3.2.2:
+    resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
+    dev: false
+
+  /react-helmet@6.1.0(react@18.2.0):
+    resolution: {integrity: sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==}
+    peerDependencies:
+      react: '>=16.3.0'
+    dependencies:
+      object-assign: 4.1.1
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-fast-compare: 3.2.2
+      react-side-effect: 2.1.2(react@18.2.0)
+    dev: false
+
   /react-hot-toast@2.4.0(csstype@3.1.2)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-qnnVbXropKuwUpriVVosgo8QrB+IaPJCpL8oBI6Ov84uvHZ5QQcTp2qg6ku2wNfgJl6rlQXJIQU5q+5lmPOutA==}
     engines: {node: '>=10'}
@@ -5163,6 +5182,14 @@ packages:
       react: '>=16.8'
     dependencies:
       '@remix-run/router': 1.3.2
+      react: 18.2.0
+    dev: false
+
+  /react-side-effect@2.1.2(react@18.2.0):
+    resolution: {integrity: sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw==}
+    peerDependencies:
+      react: ^16.3.0 || ^17.0.0 || ^18.0.0
+    dependencies:
       react: 18.2.0
     dev: false
 

--- a/src/chainlit/frontend/pnpm-lock.yaml
+++ b/src/chainlit/frontend/pnpm-lock.yaml
@@ -130,6 +130,9 @@ devDependencies:
   '@types/react-dom':
     specifier: ^18.0.10
     version: 18.0.10
+  '@types/react-helmet':
+    specifier: ^6.1.6
+    version: 6.1.6
   '@types/react-resizable':
     specifier: ^3.0.4
     version: 3.0.4
@@ -2444,6 +2447,12 @@ packages:
 
   /@types/react-dom@18.0.10:
     resolution: {integrity: sha512-E42GW/JA4Qv15wQdqJq8DL4JhNpB3prJgjgapN3qJT9K2zO5IIAQh4VXvCEDupoqAwnz0cY4RlXeC/ajX5SFHg==}
+    dependencies:
+      '@types/react': 18.0.27
+    dev: true
+
+  /@types/react-helmet@6.1.6:
+    resolution: {integrity: sha512-ZKcoOdW/Tg+kiUbkFCBtvDw0k3nD4HJ/h/B9yWxN4uDO8OkRksWTO+EL+z/Qu3aHTeTll3Ro0Cc/8UhwBCMG5A==}
     dependencies:
       '@types/react': 18.0.27
     dev: true

--- a/src/chainlit/frontend/src/components/Head.tsx
+++ b/src/chainlit/frontend/src/components/Head.tsx
@@ -1,0 +1,18 @@
+import { Helmet } from 'react-helmet';
+
+export default function Head({
+  title,
+  description
+}: {
+  title: string;
+  description: string;
+}) {
+  return (
+    <div>
+      <Helmet>
+        <title>{title}</title>
+        <meta name="description" content={description} />
+      </Helmet>
+    </div>
+  );
+}

--- a/src/chainlit/frontend/src/components/organisms/chat/index.tsx
+++ b/src/chainlit/frontend/src/components/organisms/chat/index.tsx
@@ -4,6 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { Alert, Box } from '@mui/material';
 
+import Head from 'components/Head';
 import SideView from 'components/atoms/element/sideView';
 import ErrorBoundary from 'components/atoms/errorBoundary';
 import TaskList from 'components/molecules/tasklist';
@@ -103,6 +104,7 @@ const Chat = () => {
 
   return (
     <Box display="flex" width="100%" height="0" flexGrow={1}>
+      <Head title="Chat" description="Chat" />
       <Playground />
       <ChatSettingsModal />
       <TaskList tasklist={tasklist} isMobile={false} />

--- a/src/chainlit/frontend/src/pages/Dataset.tsx
+++ b/src/chainlit/frontend/src/pages/Dataset.tsx
@@ -5,9 +5,11 @@ import Conversation from 'components/organisms/dataset';
 
 export default function Dataset() {
   return (
-    <Page>
-      <Head title="dataset" desccription="dataset" />
-      <Conversation />
-    </Page>
+    <>
+      <Head title="dataset" description="dataset" />
+      <Page>
+        <Conversation />
+      </Page>
+    </>
   );
 }

--- a/src/chainlit/frontend/src/pages/Dataset.tsx
+++ b/src/chainlit/frontend/src/pages/Dataset.tsx
@@ -1,10 +1,12 @@
 import Page from 'pages/Page';
 
+import Head from 'components/Head';
 import Conversation from 'components/organisms/dataset';
 
 export default function Dataset() {
   return (
     <Page>
+      <Head title="dataset" desccription="dataset" />
       <Conversation />
     </Page>
   );

--- a/src/chainlit/frontend/src/pages/Readme.tsx
+++ b/src/chainlit/frontend/src/pages/Readme.tsx
@@ -2,11 +2,13 @@ import Page from 'pages/Page';
 
 import { Box } from '@mui/material';
 
+import Head from 'components/Head';
 import WelcomeScreen from 'components/organisms/chat/welcomeScreen';
 
 export default function Readme() {
   return (
     <Page>
+      <Head title="Readme" description="Readme" />
       <Box sx={{ px: 2 }}>
         <WelcomeScreen />
       </Box>

--- a/src/chainlit/frontend/src/pages/Readme.tsx
+++ b/src/chainlit/frontend/src/pages/Readme.tsx
@@ -7,11 +7,13 @@ import WelcomeScreen from 'components/organisms/chat/welcomeScreen';
 
 export default function Readme() {
   return (
-    <Page>
+    <>
       <Head title="Readme" description="Readme" />
-      <Box sx={{ px: 2 }}>
-        <WelcomeScreen />
-      </Box>
-    </Page>
+      <Page>
+        <Box sx={{ px: 2 }}>
+          <WelcomeScreen />
+        </Box>
+      </Page>
+    </>
   );
 }


### PR DESCRIPTION
This PR adds [react-helmet](https://github.com/nfl/react-helmet) to modify the `<head><title> html` information when navigating to different pages. I have tested this in Chrome, Safari, and Firefox
### Chrome
<img width="454" alt="Screen Shot 2023-08-21 at 10 14 47 AM" src="https://github.com/Harvard-University-iCommons/chainlit/assets/29421667/0e4c1546-f25b-43a0-8667-1afc8fb2d044">

### Firefox
<img width="378" alt="Screen Shot 2023-08-21 at 11 59 07 AM" src="https://github.com/Harvard-University-iCommons/chainlit/assets/29421667/767d7f07-26e7-4563-893a-5bfe4b977920">

### Safari
<img width="443" alt="Screen Shot 2023-08-21 at 12 02 06 PM" src="https://github.com/Harvard-University-iCommons/chainlit/assets/29421667/cf9db931-0664-4af0-9902-70d9179254bb">

The following was added:

- `Head.tsx` component which takes a `title` and `description` strings. This should be added to different landing pages should they need to change the `title`. Note: child components that change the `title` will override the parents `title` e.g. `Home` will be overridden by `Chat`
- `Helmet` has been install via `pnpm`. Note: using this version since `react-helmet-async` wasn't working well in testing.

Note:
To test based on this on [contributing.md](https://github.com/Harvard-University-iCommons/chainlit/blob/main/.github/CONTRIBUTING.md)(follow perquisites) we need to start the Chainlit server from source
```node 
cd src
poetry run chainlit run chainlit/hello.py
```
`react-helmet` does seem to be actively used in the community but the repo doesn't seem be updated since `2020`.