### PR TITLE
a11y updates for issue tracker 

### DIFF
--- a/src/chainlit/client/base.py
+++ b/src/chainlit/client/base.py
@@ -58,6 +58,7 @@ class ElementDict(TypedDict):
     size: Optional[ElementSize]
     language: Optional[str]
     forIds: Optional[List[str]]
+    alt: Optional[str]
 
 
 class ConversationDict(TypedDict):

--- a/src/chainlit/element.py
+++ b/src/chainlit/element.py
@@ -42,6 +42,8 @@ class Element:
     for_ids: List[str] = Field(default_factory=list)
     # The language, if relevant
     language: Optional[str] = None
+    # Alt tag
+    alt: Optional[str] = None
 
     def __post_init__(self) -> None:
         trace_event(f"init {self.__class__.__name__}")
@@ -62,6 +64,7 @@ class Element:
                 "language": getattr(self, "language", None),
                 "forIds": getattr(self, "for_ids", None),
                 "conversationId": None,
+                "alt": self.alt or "",
             }
         )
         return _dict

--- a/src/chainlit/frontend/src/components/atoms/buttons/accentButton.tsx
+++ b/src/chainlit/frontend/src/components/atoms/buttons/accentButton.tsx
@@ -8,6 +8,11 @@ export default function AccentButton({ children, ...props }: ButtonProps) {
       <Button
         color={theme.palette.mode === 'dark' ? 'inherit' : 'primary'}
         {...props}
+        sx={{
+          '&:focus, &:hover, &.Mui-active, &.Mui-focusVisible': {
+            outline: '2px solid crimson'
+          }
+        }}
       >
         {children}
       </Button>

--- a/src/chainlit/frontend/src/components/atoms/buttons/button.tsx
+++ b/src/chainlit/frontend/src/components/atoms/buttons/button.tsx
@@ -21,7 +21,8 @@ export default function RegularButton({ children, ...props }: Props) {
             theme.palette.mode === 'dark'
               ? grey[700]
               : theme.palette.primary.light,
-          '&:hover': {
+          '&:focus, &:hover, &.Mui-active, &.Mui-focusVisible': {
+            outline: '2px solid crimson',
             background: (theme) =>
               theme.palette.mode === 'dark'
                 ? grey[700]

--- a/src/chainlit/frontend/src/components/atoms/buttons/userButton/index.tsx
+++ b/src/chainlit/frontend/src/components/atoms/buttons/userButton/index.tsx
@@ -24,6 +24,7 @@ export default function UserButton() {
         aria-controls={open ? 'account-menu' : undefined}
         aria-haspopup="true"
         aria-expanded={open ? 'true' : undefined}
+        aria-label="User Account Menu"
       >
         <UserAvatar />
       </IconButton>

--- a/src/chainlit/frontend/src/components/atoms/buttons/userButton/index.tsx
+++ b/src/chainlit/frontend/src/components/atoms/buttons/userButton/index.tsx
@@ -24,7 +24,7 @@ export default function UserButton() {
         aria-controls={open ? 'account-menu' : undefined}
         aria-haspopup="true"
         aria-expanded={open ? 'true' : undefined}
-        aria-label="User Account Menu"
+        aria-label="Options Menu"
       >
         <UserAvatar />
       </IconButton>

--- a/src/chainlit/frontend/src/components/atoms/buttons/userButton/menu.tsx
+++ b/src/chainlit/frontend/src/components/atoms/buttons/userButton/menu.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 
+import CloseIcon from '@mui/icons-material/Close';
 import KeyIcon from '@mui/icons-material/Key';
 import LogoutIcon from '@mui/icons-material/Logout';
 import SettingsIcon from '@mui/icons-material/Settings';
@@ -43,21 +44,35 @@ export default function UserMenu({ anchorEl, open, handleClose }: Props) {
   );
 
   const settingsItem = (
-    <MenuItem
-      key="settings"
-      onClick={() => {
-        setAppSettings((old) => ({ ...old, open: true }));
-        handleClose();
-      }}
-    >
-      <ListItemIcon>
-        <SettingsIcon fontSize="small" aria-label="Settings Menu" />
-      </ListItemIcon>
-      <ListItemText>Settings</ListItemText>
-      <Typography variant="body2" color="text.secondary">
-        S
-      </Typography>
-    </MenuItem>
+    <>
+      <MenuItem
+        key="settings"
+        onClick={() => {
+          setAppSettings((old) => ({ ...old, open: true }));
+          handleClose();
+        }}
+      >
+        <ListItemIcon>
+          <SettingsIcon fontSize="small" aria-label="Settings Menu" />
+        </ListItemIcon>
+        <ListItemText>Settings</ListItemText>
+      </MenuItem>
+      <MenuItem
+        key="close"
+        onClick={() => {
+          handleClose();
+        }}
+      >
+        <ListItemIcon>
+          <CloseIcon
+            style={{ paddingLeft: 0 }}
+            fontSize="small"
+            aria-label="close settings"
+          />
+        </ListItemIcon>
+        <ListItemText>Close</ListItemText>
+      </MenuItem>
+    </>
   );
 
   const apiKeysItem = requiredKeys && (

--- a/src/chainlit/frontend/src/components/atoms/buttons/userButton/menu.tsx
+++ b/src/chainlit/frontend/src/components/atoms/buttons/userButton/menu.tsx
@@ -51,7 +51,7 @@ export default function UserMenu({ anchorEl, open, handleClose }: Props) {
       }}
     >
       <ListItemIcon>
-        <SettingsIcon fontSize="small" />
+        <SettingsIcon fontSize="small" aria-label="Settings Menu" />
       </ListItemIcon>
       <ListItemText>Settings</ListItemText>
       <Typography variant="body2" color="text.secondary">

--- a/src/chainlit/frontend/src/components/atoms/element/avatar.tsx
+++ b/src/chainlit/frontend/src/components/atoms/element/avatar.tsx
@@ -9,11 +9,16 @@ interface Props {
 
 export default function AvatarElement({ element, author }: Props) {
   const src = element.url || URL.createObjectURL(new Blob([element.content!]));
+  const alt = element.alt;
   const className = `message-avatar`;
   return (
     <Tooltip title={author}>
       <span className={className}>
-        <Avatar sx={{ width: 38, height: 38, mt: '-4px' }} src={src} />
+        <Avatar
+          sx={{ width: 38, height: 38, mt: '-4px' }}
+          alt={alt}
+          src={src}
+        />
       </span>
     </Tooltip>
   );

--- a/src/chainlit/frontend/src/components/atoms/logo.tsx
+++ b/src/chainlit/frontend/src/components/atoms/logo.tsx
@@ -13,5 +13,5 @@ interface Props {
 export const Logo = ({ width, style }: Props) => {
   const { theme } = useRecoilValue(settingsState);
   const src = theme === 'light' ? LogoLight : LogoDark;
-  return <img src={src} style={style} width={width || 40} />;
+  return <img src={src} style={style} width={width || 40} alt="Chainlit" />;
 };

--- a/src/chainlit/frontend/src/components/atoms/switch.tsx
+++ b/src/chainlit/frontend/src/components/atoms/switch.tsx
@@ -55,13 +55,21 @@ const StyledSwitch = styled((props: MSwitchProps) => (
   const isDarkMode = theme.palette.mode === 'dark';
 
   return {
+    '&:focus, &:hover, &.Mui-active, &.Mui-focusVisible': {
+      outline: '2px solid crimson',
+      borderRadius: 26 / 2
+    },
     width: 40,
     height: 24,
     padding: 0,
+    overflow: 'visible',
     '& .MuiSwitch-switchBase': {
       margin: 0,
       padding: '4px',
       transitionDuration: '300ms',
+      '&:focus, &:hover, &.Mui-active, &.Mui-focusVisible': {
+        outline: '2px solid crimson'
+      },
       '&.Mui-checked': {
         transform: 'translateX(16px)',
         color: '#fff',

--- a/src/chainlit/frontend/src/components/molecules/inputLabel.tsx
+++ b/src/chainlit/frontend/src/components/molecules/inputLabel.tsx
@@ -24,7 +24,7 @@ export default function inputLabel({
           sx={{
             fontWeight: 600,
             fontSize: '12px',
-            color: 'grey.500'
+            color: 'grey.800'
           }}
         >
           {label}

--- a/src/chainlit/frontend/src/components/molecules/newChatButton.tsx
+++ b/src/chainlit/frontend/src/components/molecules/newChatButton.tsx
@@ -40,6 +40,11 @@ export default function NewChatButton() {
         variant="outlined"
         onClick={handleClickOpen}
         startIcon={<AddIcon />}
+        sx={{
+          '&:focus, &:hover, &.Mui-active, &.Mui-focusVisible': {
+            outline: '2px solid crimson'
+          }
+        }}
       >
         New Chat
       </AccentButton>

--- a/src/chainlit/frontend/src/components/molecules/settingsModal.tsx
+++ b/src/chainlit/frontend/src/components/molecules/settingsModal.tsx
@@ -58,13 +58,13 @@ export default function SettingsModal() {
             <ListItemText id="list-expand-all" primary="Expand Messages" />
             <Box>
               <Switch
-                id="switch-expand-all"
+                id="switch-expand-all-messages"
                 onChange={() =>
                   setSettings((old) => ({ ...old, expandAll: !old.expandAll }))
                 }
                 checked={settings.expandAll}
                 inputProps={{
-                  'aria-labelledby': 'switch-expand-all'
+                  'aria-label': 'switch expand all messages'
                 }}
               />
             </Box>

--- a/src/chainlit/frontend/src/components/molecules/settingsModal.tsx
+++ b/src/chainlit/frontend/src/components/molecules/settingsModal.tsx
@@ -64,7 +64,7 @@ export default function SettingsModal() {
                 }
                 checked={settings.expandAll}
                 inputProps={{
-                  'aria-label': 'switch expand all messages'
+                  'aria-label': 'Expand Messages'
                 }}
               />
             </Box>

--- a/src/chainlit/frontend/src/components/molecules/settingsModal.tsx
+++ b/src/chainlit/frontend/src/components/molecules/settingsModal.tsx
@@ -1,5 +1,6 @@
 import { useRecoilState } from 'recoil';
 
+import CloseIcon from '@mui/icons-material/Close';
 import DarkModeOutlined from '@mui/icons-material/DarkModeOutlined';
 import EmojiObjectsIcon from '@mui/icons-material/EmojiObjects';
 import ExpandIcon from '@mui/icons-material/Expand';
@@ -7,6 +8,7 @@ import {
   Box,
   Dialog,
   DialogContent,
+  IconButton,
   List,
   ListItem,
   ListItemIcon,
@@ -20,11 +22,11 @@ import { settingsState } from 'state/settings';
 
 export default function SettingsModal() {
   const [settings, setSettings] = useRecoilState(settingsState);
-
+  const handleClose = () => setSettings((old) => ({ ...old, open: false }));
   return (
     <Dialog
       open={settings.open}
-      onClose={() => setSettings((old) => ({ ...old, open: false }))}
+      onClose={handleClose}
       id="settings-dialog"
       PaperProps={{
         sx: {
@@ -35,7 +37,19 @@ export default function SettingsModal() {
       <DialogContent>
         <List
           sx={{ width: '100%', maxWidth: 360 }}
-          subheader={<ListSubheader>Settings</ListSubheader>}
+          subheader={
+            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+              <ListSubheader>Settings</ListSubheader>
+              <IconButton
+                edge={false}
+                sx={{ ml: 'auto' }}
+                onClick={handleClose}
+                aria-label="close settings modal"
+              >
+                <CloseIcon />
+              </IconButton>
+            </div>
+          }
         >
           <ListItem sx={{ display: 'flex', gap: 2 }}>
             <ListItemIcon>

--- a/src/chainlit/frontend/src/components/organisms/chat/inputBox/input.tsx
+++ b/src/chainlit/frontend/src/components/organisms/chat/inputBox/input.tsx
@@ -99,8 +99,9 @@ const Input = ({ onSubmit, onReply }: Props) => {
           disabled={disabled}
           color="inherit"
           onClick={() => setChatSettings((old) => ({ ...old, open: true }))}
+          aria-label="Settings Panel"
         >
-          <TuneIcon aria-label="Filter Menu" />
+          <TuneIcon />
         </IconButton>
       )}
       <HistoryButton onClick={onHistoryClick} />

--- a/src/chainlit/frontend/src/components/organisms/chat/inputBox/input.tsx
+++ b/src/chainlit/frontend/src/components/organisms/chat/inputBox/input.tsx
@@ -100,7 +100,7 @@ const Input = ({ onSubmit, onReply }: Props) => {
           color="inherit"
           onClick={() => setChatSettings((old) => ({ ...old, open: true }))}
         >
-          <TuneIcon />
+          <TuneIcon aria-label="Filter Menu" />
         </IconButton>
       )}
       <HistoryButton onClick={onHistoryClick} />
@@ -109,7 +109,7 @@ const Input = ({ onSubmit, onReply }: Props) => {
 
   const endAdornment = (
     <IconButton disabled={disabled} color="inherit" onClick={() => submit()}>
-      <SendIcon />
+      <SendIcon aria-label="Send Message" />
     </IconButton>
   );
 

--- a/src/chainlit/frontend/src/components/organisms/chat/inputBox/waterMark.tsx
+++ b/src/chainlit/frontend/src/components/organisms/chat/inputBox/waterMark.tsx
@@ -13,6 +13,7 @@ export default function WaterMark() {
           alignItems: 'center',
           textDecoration: 'none'
         }}
+        aria-label="Built with link"
       >
         <Typography fontSize="12px" color="text.secondary">
           Built with

--- a/src/chainlit/frontend/src/components/organisms/dataset/deleteConversationButton.tsx
+++ b/src/chainlit/frontend/src/components/organisms/dataset/deleteConversationButton.tsx
@@ -57,6 +57,7 @@ export default function DeleteConversationButton({
         size="small"
         color="error"
         onClick={handleClickOpen}
+        aria-label="delete conversation"
       >
         <DeleteOutline />
       </IconButton>

--- a/src/chainlit/frontend/src/components/organisms/dataset/filters/SearchBar.tsx
+++ b/src/chainlit/frontend/src/components/organisms/dataset/filters/SearchBar.tsx
@@ -83,7 +83,7 @@ export default function SearchBar() {
         onChange={(e) => _onChange(e.target.value)}
       />
       <SearchIconWrapper>
-        <IconButton onClick={clear}>
+        <IconButton onClick={clear} aria-label="clear searchbar">
           <CloseIcon />
         </IconButton>
       </SearchIconWrapper>

--- a/src/chainlit/frontend/src/components/organisms/dataset/openConversationButton.tsx
+++ b/src/chainlit/frontend/src/components/organisms/dataset/openConversationButton.tsx
@@ -16,7 +16,7 @@ export default function OpenConversationButton({ conversationId }: Props) {
       size="small"
       color="primary"
     >
-      <VisibilityIcon aria-label="view conversation" />
+      <VisibilityIcon aria-label={`view conversation ${conversationId}`} />
     </IconButton>
   );
 }

--- a/src/chainlit/frontend/src/components/organisms/dataset/openConversationButton.tsx
+++ b/src/chainlit/frontend/src/components/organisms/dataset/openConversationButton.tsx
@@ -16,7 +16,7 @@ export default function OpenConversationButton({ conversationId }: Props) {
       size="small"
       color="primary"
     >
-      <VisibilityIcon aria-label={`view conversation ${conversationId}`} />
+      <VisibilityIcon aria-label="view conversation" />
     </IconButton>
   );
 }

--- a/src/chainlit/frontend/src/components/organisms/dataset/openConversationButton.tsx
+++ b/src/chainlit/frontend/src/components/organisms/dataset/openConversationButton.tsx
@@ -16,7 +16,7 @@ export default function OpenConversationButton({ conversationId }: Props) {
       size="small"
       color="primary"
     >
-      <VisibilityIcon />
+      <VisibilityIcon aria-label="view conversation" />
     </IconButton>
   );
 }

--- a/src/chainlit/frontend/src/components/organisms/header.tsx
+++ b/src/chainlit/frontend/src/components/organisms/header.tsx
@@ -1,5 +1,6 @@
+import { grey } from 'palette';
 import { useRef, useState } from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 
 import MenuIcon from '@mui/icons-material/Menu';
@@ -9,10 +10,12 @@ import {
   Button,
   IconButton,
   Menu,
+  MenuItem,
   Stack,
   Toolbar,
   useTheme
 } from '@mui/material';
+import { Theme } from '@mui/material';
 import useMediaQuery from '@mui/material/useMediaQuery';
 
 import RegularButton from 'components/atoms/buttons/button';
@@ -27,6 +30,11 @@ interface INavItem {
   label: string;
 }
 
+interface IMenuItem {
+  to: string;
+  label: string;
+  tabIndex: number;
+}
 function ActiveNavItem({ to, label }: INavItem) {
   return (
     <RegularButton component={Link} to={to} key={to}>
@@ -35,25 +43,51 @@ function ActiveNavItem({ to, label }: INavItem) {
   );
 }
 
+const styleOverrides = {
+  inactive: {
+    textTransform: 'none',
+    color: 'text.secondary',
+    '&:focus, &:hover, &.Mui-active, &.Mui-focusVisible': {
+      outline: '2px solid crimson',
+      background: 'transparent'
+    }
+  },
+  active: {
+    textTransform: 'none',
+    color: (theme: Theme) =>
+      theme.palette.mode === 'dark'
+        ? 'text.primary'
+        : theme.palette.primary.main,
+    background: (theme: Theme) =>
+      theme.palette.mode === 'dark' ? grey[700] : theme.palette.primary.light,
+    '&:focus, &:hover, &.Mui-active, &.Mui-focusVisible': {
+      outline: '2px solid crimson',
+      background: (theme: Theme) =>
+        theme.palette.mode === 'dark' ? grey[700] : theme.palette.primary.light
+    }
+  }
+};
+
 function NavItem({ to, label }: INavItem) {
   return (
-    <Button
-      component={Link}
-      to={to}
-      key={to}
-      sx={{
-        textTransform: 'none',
-        color: 'text.secondary',
-        '&:focus, &:hover, &.Mui-active, &.Mui-focusVisible': {
-          outline: '2px solid crimson',
-          background: 'transparent'
-        }
-      }}
-    >
+    <Button component={Link} to={to} key={to} sx={styleOverrides.inactive}>
       {label}
     </Button>
   );
 }
+
+const ActiveMenuItem = ({ to, label, tabIndex }: IMenuItem) => (
+  <MenuItem
+    component={Link}
+    key={to}
+    to={to}
+    tabIndex={tabIndex}
+    autoFocus={true}
+    sx={styleOverrides.active}
+  >
+    {label}
+  </MenuItem>
+);
 
 interface NavProps {
   hasDb?: boolean;
@@ -131,7 +165,22 @@ function Nav({ hasDb, hasReadme }: NavProps) {
           anchorOrigin={{ vertical: 'top', horizontal: 'left' }}
           transformOrigin={{ vertical: 'bottom', horizontal: 'left' }}
         >
-          {nav}
+          {tabs.map((t, index) => {
+            const active = location.pathname === t.to;
+            return active ? (
+              <ActiveMenuItem {...t} tabIndex={index} />
+            ) : (
+              <MenuItem
+                sx={styleOverrides.inactive}
+                key={t.to}
+                component={Link}
+                to={t.to}
+                tabIndex={index}
+              >
+                {t.label}
+              </MenuItem>
+            );
+          })}
         </Menu>
       </>
     );

--- a/src/chainlit/frontend/src/components/organisms/header.tsx
+++ b/src/chainlit/frontend/src/components/organisms/header.tsx
@@ -44,7 +44,8 @@ function NavItem({ to, label }: INavItem) {
       sx={{
         textTransform: 'none',
         color: 'text.secondary',
-        '&:hover': {
+        '&:focus, &:hover, &.Mui-active, &.Mui-focusVisible': {
+          outline: '2px solid crimson',
           background: 'transparent'
         }
       }}

--- a/src/chainlit/frontend/src/components/organisms/header.tsx
+++ b/src/chainlit/frontend/src/components/organisms/header.tsx
@@ -1,6 +1,6 @@
 import { grey } from 'palette';
 import { useRef, useState } from 'react';
-import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 
 import MenuIcon from '@mui/icons-material/Menu';

--- a/src/chainlit/frontend/src/components/organisms/inputs/inputStateHandler.tsx
+++ b/src/chainlit/frontend/src/components/organisms/inputs/inputStateHandler.tsx
@@ -18,7 +18,8 @@ export default function InputStateHandler(
     id,
     label,
     notificationsCount,
-    tooltip
+    tooltip,
+    type
   } = props;
 
   return (
@@ -31,7 +32,11 @@ export default function InputStateHandler(
           notificationsCount={notificationsCount}
         />
       ) : null}
-      <FormControl error={hasError} fullWidth>
+      <FormControl
+        error={hasError}
+        fullWidth
+        aria-label={label && type ? `${label} ${type}` : label || type}
+      >
         {children}
         {description ? <FormHelperText>{description}</FormHelperText> : null}
       </FormControl>

--- a/src/chainlit/frontend/src/components/organisms/inputs/inputStateHandler.tsx
+++ b/src/chainlit/frontend/src/components/organisms/inputs/inputStateHandler.tsx
@@ -18,8 +18,7 @@ export default function InputStateHandler(
     id,
     label,
     notificationsCount,
-    tooltip,
-    inputType
+    tooltip
   } = props;
 
   return (
@@ -32,13 +31,7 @@ export default function InputStateHandler(
           notificationsCount={notificationsCount}
         />
       ) : null}
-      <FormControl
-        error={hasError}
-        fullWidth
-        aria-label={
-          label && inputType ? `${label} ${inputType}` : label || inputType
-        }
-      >
+      <FormControl error={hasError} fullWidth aria-label={label}>
         {children}
         {description ? <FormHelperText>{description}</FormHelperText> : null}
       </FormControl>

--- a/src/chainlit/frontend/src/components/organisms/inputs/inputStateHandler.tsx
+++ b/src/chainlit/frontend/src/components/organisms/inputs/inputStateHandler.tsx
@@ -19,7 +19,7 @@ export default function InputStateHandler(
     label,
     notificationsCount,
     tooltip,
-    type
+    inputType
   } = props;
 
   return (
@@ -35,7 +35,9 @@ export default function InputStateHandler(
       <FormControl
         error={hasError}
         fullWidth
-        aria-label={label && type ? `${label} ${type}` : label || type}
+        aria-label={
+          label && inputType ? `${label} ${inputType}` : label || inputType
+        }
       >
         {children}
         {description ? <FormHelperText>{description}</FormHelperText> : null}

--- a/src/chainlit/frontend/src/components/organisms/inputs/selectInput.tsx
+++ b/src/chainlit/frontend/src/components/organisms/inputs/selectInput.tsx
@@ -99,6 +99,12 @@ export default function SelectInput({
         onChange={onChange}
         size={size}
         disabled={disabled}
+        // check if value is a string so we dont create aria-label with numbers
+        aria-label={
+          (typeof value == 'number'
+            ? items?.find((item) => item.value === value)?.label
+            : value) + ' list box'
+        }
         renderValue={() =>
           (renderLabel && renderLabel()) ||
           `${items?.find((item) => item.value === value)?.label}`

--- a/src/chainlit/frontend/src/components/organisms/inputs/selectInput.tsx
+++ b/src/chainlit/frontend/src/components/organisms/inputs/selectInput.tsx
@@ -99,12 +99,7 @@ export default function SelectInput({
         onChange={onChange}
         size={size}
         disabled={disabled}
-        // check if value is a string so we dont create aria-label with numbers
-        aria-label={
-          (typeof value == 'number'
-            ? items?.find((item) => item.value === value)?.label
-            : value) + ' list box'
-        }
+        aria-label={label}
         renderValue={() =>
           (renderLabel && renderLabel()) ||
           `${items?.find((item) => item.value === value)?.label}`

--- a/src/chainlit/frontend/src/components/organisms/inputs/selectInput.tsx
+++ b/src/chainlit/frontend/src/components/organisms/inputs/selectInput.tsx
@@ -45,6 +45,7 @@ export const renderMenuItem = ({
   <MenuItem
     value={item.value}
     key={`select-${index}`}
+    aria-label={item.label}
     sx={{
       display: 'flex',
       justifyContent: 'space-between',

--- a/src/chainlit/frontend/src/components/organisms/playground/index.tsx
+++ b/src/chainlit/frontend/src/components/organisms/playground/index.tsx
@@ -153,7 +153,7 @@ export default function Playground() {
             onClick={toggleDrawer}
             sx={{ mr: '4px' }}
           >
-            <SettingsIcon />
+            <SettingsIcon aria-label="Settings Menu" />
           </IconButton>
           <IconButton edge="end" id="close-playground" onClick={handleClose}>
             <CloseIcon />

--- a/src/chainlit/frontend/src/components/organisms/slider.tsx
+++ b/src/chainlit/frontend/src/components/organisms/slider.tsx
@@ -25,12 +25,13 @@ const _Slider = ({
       label={label}
       tooltip={tooltip}
       notificationsCount={sliderProps.value?.toString()}
+      type="slider"
     >
       <StyledSlider
         {...sliderProps}
         id={id}
         name={id}
-        aria-label={label + ' slider'}
+        aria-label={label + ' slider thumb'}
       />
     </InputStateHandler>
   );
@@ -47,13 +48,18 @@ const StyledSlider = styled(Slider)(({ theme }) => {
       border: 'none',
       color: grey[500]
     },
+    '& .MuiSlider-root, &:focus, &:hover, &.Mui-focusVisible': {
+      // boxShadow: 'inherit'
+      outline: '2px solid crimson'
+    },
     '& .MuiSlider-thumb': {
       height: 15,
       width: 15,
       backgroundColor: isLightMode ? grey[600] : 'white',
       border: `4px solid ${isLightMode ? grey[300] : grey[800]}`,
-      '&:focus, &:hover, &.Mui-active, &.Mui-focusVisible': {
-        boxShadow: 'inherit'
+      '&:focus, &:hover, &.Mui-active, &.Mui-focusVisible, & .MuiSlider-root': {
+        boxShadow: 'inherit',
+        outline: '2px solid crimson'
       },
       '&:before': {
         display: 'none'

--- a/src/chainlit/frontend/src/components/organisms/slider.tsx
+++ b/src/chainlit/frontend/src/components/organisms/slider.tsx
@@ -25,14 +25,8 @@ const _Slider = ({
       label={label}
       tooltip={tooltip}
       notificationsCount={sliderProps.value?.toString()}
-      inputType="slider"
     >
-      <StyledSlider
-        {...sliderProps}
-        id={id}
-        name={id}
-        aria-label={label + ' slider thumb'}
-      />
+      <StyledSlider {...sliderProps} id={id} name={id} aria-label={label} />
     </InputStateHandler>
   );
 };

--- a/src/chainlit/frontend/src/components/organisms/slider.tsx
+++ b/src/chainlit/frontend/src/components/organisms/slider.tsx
@@ -26,7 +26,12 @@ const _Slider = ({
       tooltip={tooltip}
       notificationsCount={sliderProps.value?.toString()}
     >
-      <StyledSlider {...sliderProps} id={id} name={id} aria-label={label} />
+      <StyledSlider
+        {...sliderProps}
+        id={id}
+        name={id}
+        aria-label={label + ' slider'}
+      />
     </InputStateHandler>
   );
 };

--- a/src/chainlit/frontend/src/components/organisms/slider.tsx
+++ b/src/chainlit/frontend/src/components/organisms/slider.tsx
@@ -25,7 +25,7 @@ const _Slider = ({
       label={label}
       tooltip={tooltip}
       notificationsCount={sliderProps.value?.toString()}
-      type="slider"
+      inputType="slider"
     >
       <StyledSlider
         {...sliderProps}

--- a/src/chainlit/frontend/src/components/organisms/slider.tsx
+++ b/src/chainlit/frontend/src/components/organisms/slider.tsx
@@ -26,7 +26,7 @@ const _Slider = ({
       tooltip={tooltip}
       notificationsCount={sliderProps.value?.toString()}
     >
-      <StyledSlider {...sliderProps} id={id} name={id} />
+      <StyledSlider {...sliderProps} id={id} name={id} aria-label={label} />
     </InputStateHandler>
   );
 };

--- a/src/chainlit/frontend/src/pages/Dataset.tsx
+++ b/src/chainlit/frontend/src/pages/Dataset.tsx
@@ -6,7 +6,7 @@ import Conversation from 'components/organisms/dataset';
 export default function Dataset() {
   return (
     <>
-      <Head title="dataset" description="dataset" />
+      <Head title="History" description="History" />
       <Page>
         <Conversation />
       </Page>

--- a/src/chainlit/frontend/src/state/element.ts
+++ b/src/chainlit/frontend/src/state/element.ts
@@ -27,6 +27,7 @@ interface TElement<T> {
   conversationId?: string;
   forIds?: string[];
   url?: string;
+  alt?: string;
 }
 
 interface TMessageElement<T> extends TElement<T> {

--- a/src/chainlit/frontend/src/types/Input.ts
+++ b/src/chainlit/frontend/src/types/Input.ts
@@ -8,6 +8,7 @@ interface IInput {
   notificationsCount?: number | string;
   size?: 'small' | 'medium';
   tooltip?: string;
+  type?: string;
 }
 
 export type { IInput };

--- a/src/chainlit/frontend/src/types/Input.ts
+++ b/src/chainlit/frontend/src/types/Input.ts
@@ -8,7 +8,7 @@ interface IInput {
   notificationsCount?: number | string;
   size?: 'small' | 'medium';
   tooltip?: string;
-  type?: string;
+  inputType?: string;
 }
 
 export type { IInput };

--- a/src/chainlit/frontend/src/types/Input.ts
+++ b/src/chainlit/frontend/src/types/Input.ts
@@ -8,7 +8,6 @@ interface IInput {
   notificationsCount?: number | string;
   size?: 'small' | 'medium';
   tooltip?: string;
-  inputType?: string;
 }
 
 export type { IInput };


### PR DESCRIPTION
This PR fixes the following issues from the [Issue Tracker doc](https://docs.google.com/spreadsheets/d/1e8DPalavZp6LMJs6iEp8STKCZtArLZ2u1tUYkSN3Nq4/edit#gid=371793552&fvid=880066983)
`2, 3, 4, 8, 9, 10, 11, 13, 14, 15, 17, 19, 20, 21, 23, 27`

| Issue      | Description |
| :----: | ----------- |
| 2      | Avatar - Settings Modal - There is no close button to close the dialog. It relies on the escape key or clicking out of the modal. This can trap some users inthe modal state, for example mobile devices with AT, or alt navigation users.        |
| 3      | Avatar - Settings Menu - There is no close button to close the menu. It relies on the escape key or clicking out of the modal. This can trap some users in the modal state, for example, mobile devices with AT, or alt navigation users.         |
| 4      | Chat - filter Modal - There is no focus indicator in the settings modal which makes it unclear which element is currently active.        |
| 8      | History - Feedback label - The label text on the history page is not strong enough against the background.        |
| 9      | Avatar - Settings button has no accessible name.        |
| 10      | Chat - The filter button in the text input for typing chat does not have an accessible name.         |
| 11      | Avatar - Settings Modal  - The "Expand Messages" check box does not have an accessible name.         |
| 13      | Chat - The button used to send a message in the text input does not have an accessible name.         |
| 15      | Chat - The chainlit logo image does not have alternative text.         |
| 17      | Chat - The Harvard logo image has no alternative text.         |
| 20      | History - Links in the table associated with the view icon do not have accessible names to describe them.        |
| 21      | History - Buttons in the table associated with the delete icon do not have accessible names to describe them.         |
| 23      | Chat - Filter Modal - The temperature slider input does not have a label or accessible name.        |
| 27      | History -      The author form elements name is derived from the currently selected option in the options list and does not match the visible label.    |

- Added additional `alt` property for `Avatar` customization e.g.
```python
   await Avatar(
        name="Tool 1",
        url="https://avatars....",
        alt="Harvard Shield"
    ).send()
```

Note: This doesn't cover every a11y issue, but since we want to get some feedback from `DAS` I am including what i have currently in this PR