### PR TITLE
add sidebar

### DIFF
--- a/src/chainlit/frontend/src/components/Sidebar.tsx
+++ b/src/chainlit/frontend/src/components/Sidebar.tsx
@@ -1,0 +1,129 @@
+import * as React from 'react';
+
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import MenuIcon from '@mui/icons-material/DoubleArrow';
+import Box from '@mui/material/Box';
+import CssBaseline from '@mui/material/CssBaseline';
+import Divider from '@mui/material/Divider';
+import Drawer from '@mui/material/Drawer';
+import IconButton from '@mui/material/IconButton';
+import { styled, useTheme } from '@mui/material/styles';
+
+import HarvardIcon from '../assets/HarvardUniversity_Horizontal_Large_Shield_RGB.png';
+import DarkHarvardIcon from '../assets/HarvardUniversity_Horizontal_Large_Shield_Reverse_RGB.png';
+
+const drawerWidth = 340;
+
+const Main = styled('main', { shouldForwardProp: (prop) => prop !== 'open' })<{
+  open?: boolean;
+}>(({ theme, open }) => ({
+  flexGrow: 1,
+  padding: theme.spacing(0),
+  width: 0,
+  transition: theme.transitions.create('margin', {
+    easing: theme.transitions.easing.sharp,
+    duration: theme.transitions.duration.leavingScreen
+  }),
+  marginLeft: `-${drawerWidth}px`,
+  ...(open && {
+    transition: theme.transitions.create('margin', {
+      easing: theme.transitions.easing.easeOut,
+      duration: theme.transitions.duration.enteringScreen
+    }),
+    marginLeft: 0
+  })
+}));
+
+const DrawerHeader = styled('div')(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  padding: theme.spacing(0, 1),
+  // necessary for content to be below app bar
+  ...theme.mixins.toolbar,
+  justifyContent: 'flex-end'
+}));
+
+export default function PersistentDrawerLeft() {
+  const theme = useTheme();
+  const [open, setOpen] = React.useState(false);
+
+  const handleDrawerOpen = () => {
+    setOpen(true);
+  };
+
+  const handleDrawerClose = () => {
+    setOpen(false);
+  };
+  console.log('mode', theme.palette.mode);
+  return (
+    <Box sx={{ display: 'flex' }}>
+      <CssBaseline />
+      <IconButton
+        color="inherit"
+        aria-label="open drawer"
+        onClick={handleDrawerOpen}
+        edge="start"
+        sx={{
+          mb: { lg: '7rem' },
+          ml: '2px',
+          mr: 0,
+          bottom: '22rem',
+          ...(open && { display: 'none' })
+        }}
+      >
+        <MenuIcon />
+      </IconButton>
+      <Drawer
+        sx={{
+          width: drawerWidth,
+          flexShrink: 0,
+          '& .MuiDrawer-paper': {
+            width: drawerWidth,
+            boxSizing: 'border-box'
+          },
+          '& .MuiPaper-root': {
+            marginTop: '4rem'
+          }
+        }}
+        variant="persistent"
+        anchor="left"
+        open={open}
+      >
+        <DrawerHeader>
+          <IconButton onClick={handleDrawerClose}>
+            {theme.direction === 'ltr' ? (
+              <ChevronLeftIcon />
+            ) : (
+              <ChevronRightIcon />
+            )}
+          </IconButton>
+        </DrawerHeader>
+        <Divider />
+        <div style={{ padding: '1rem' }}>
+          <img
+            src={theme.palette.mode == 'dark' ? DarkHarvardIcon : HarvardIcon}
+            alt="harvard icon"
+          />
+          <h1>AI Sandbox</h1>
+          <h2>(Pilot Version)</h2>
+          <p>
+            Use of this AI Sandbox is subject to data handling practices as
+            outlined in the
+            <a href="https://policy.security.harvard.edu/">
+              {' '}
+              University's Information Security Policies
+            </a>
+            . The AI Sandbox is approived for use with Medium Risk Confidential
+            data(L3) and below. Do not enter any High Risk Confidential data (L4
+            or above). Foraddition information, review the University's
+            guidelines for the use of generative AI.
+          </p>
+        </div>
+      </Drawer>
+      <Main open={open}>
+        <DrawerHeader />
+      </Main>
+    </Box>
+  );
+}

--- a/src/chainlit/frontend/src/components/Sidebar.tsx
+++ b/src/chainlit/frontend/src/components/Sidebar.tsx
@@ -46,7 +46,7 @@ const DrawerHeader = styled('div')(({ theme }) => ({
 
 export default function PersistentDrawerLeft() {
   const theme = useTheme();
-  const [open, setOpen] = React.useState(false);
+  const [open, setOpen] = React.useState(true);
 
   const handleDrawerOpen = () => {
     setOpen(true);
@@ -55,7 +55,7 @@ export default function PersistentDrawerLeft() {
   const handleDrawerClose = () => {
     setOpen(false);
   };
-  console.log('mode', theme.palette.mode);
+
   return (
     <Box sx={{ display: 'flex' }}>
       <CssBaseline />

--- a/src/chainlit/frontend/src/components/Sidebar.tsx
+++ b/src/chainlit/frontend/src/components/Sidebar.tsx
@@ -117,7 +117,7 @@ export default function PersistentDrawerLeft() {
             </a>
             . The AI Sandbox is approived for use with Medium Risk Confidential
             data(L3) and below. Do not enter any High Risk Confidential data (L4
-            or above). Foraddition information, review the University's
+            or above). For additional information, review the University's
             guidelines for the use of generative AI.
           </p>
         </div>

--- a/src/chainlit/frontend/src/components/Sidebar.tsx
+++ b/src/chainlit/frontend/src/components/Sidebar.tsx
@@ -61,7 +61,7 @@ export default function PersistentDrawerLeft() {
       <CssBaseline />
       <IconButton
         color="inherit"
-        aria-label="open drawer"
+        aria-label="open sidebar"
         onClick={handleDrawerOpen}
         edge="start"
         sx={{
@@ -91,7 +91,7 @@ export default function PersistentDrawerLeft() {
         open={open}
       >
         <DrawerHeader>
-          <IconButton onClick={handleDrawerClose}>
+          <IconButton onClick={handleDrawerClose} aria-label="close sidebar">
             {theme.direction === 'ltr' ? (
               <ChevronLeftIcon />
             ) : (
@@ -104,6 +104,7 @@ export default function PersistentDrawerLeft() {
           <img
             src={theme.palette.mode == 'dark' ? DarkHarvardIcon : HarvardIcon}
             alt="harvard icon"
+            style={{ width: '18rem' }}
           />
           <h1>AI Sandbox</h1>
           <h2>(Pilot Version)</h2>

--- a/src/chainlit/frontend/src/components/organisms/chat/index.tsx
+++ b/src/chainlit/frontend/src/components/organisms/chat/index.tsx
@@ -5,6 +5,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { Alert, Box } from '@mui/material';
 
 import Head from 'components/Head';
+import Sidebar from 'components/Sidebar';
 import SideView from 'components/atoms/element/sideView';
 import ErrorBoundary from 'components/atoms/errorBoundary';
 import TaskList from 'components/molecules/tasklist';
@@ -105,6 +106,7 @@ const Chat = () => {
   return (
     <Box display="flex" width="100%" height="0" flexGrow={1}>
       <Head title="Chat" description="Chat" />
+      <Sidebar />
       <Playground />
       <ChatSettingsModal />
       <TaskList tasklist={tasklist} isMobile={false} />


### PR DESCRIPTION
This PR adds a sidebar to the chat page.

- Works with Dark mode
### Notes:
- I used images stored locally(uncommitted in this PR), we can change the location if links are provided
- I also used a generic icon(arrows) for the sidebar icon, but that can be changed.
- The current implementation defaults to open
- Fixed typo for `additional` not shown in the images
<img width="1766" alt="Screen Shot 2023-08-29 at 10 04 26 PM" src="https://github.com/Harvard-University-iCommons/chainlit/assets/29421667/dcc2d1f1-3c91-4d62-82a0-66571910914e">
<img width="1760" alt="Screen Shot 2023-08-29 at 10 11 56 PM" src="https://github.com/Harvard-University-iCommons/chainlit/assets/29421667/e3e83309-63aa-4fd5-9c3d-8a9bb6259f32">
<img width="1766" alt="Screen Shot 2023-08-29 at 10 12 04 PM" src="https://github.com/Harvard-University-iCommons/chainlit/assets/29421667/0c779739-cb95-4883-b5ae-0c7b5a50ddb6">
