### PR TITLE
update footer and sidebar with links

### DIFF
--- a/src/chainlit/frontend/src/components/Sidebar.tsx
+++ b/src/chainlit/frontend/src/components/Sidebar.tsx
@@ -113,14 +113,34 @@ export default function PersistentDrawerLeft() {
           <p>
             Use of this AI Sandbox is subject to data handling practices as
             outlined in the
-            <a href="https://policy.security.harvard.edu/">
+            <a
+              href="https://policy.security.harvard.edu/"
+              aria-label="university's information security policies"
+            >
               {' '}
               University's Information Security Policies
             </a>
-            . The AI Sandbox is approived for use with Medium Risk Confidential
-            data(L3) and below. Do not enter any High Risk Confidential data (L4
-            or above). For additional information, review the University's
-            guidelines for the use of generative AI.
+            {'. '} The AI Sandbox is approived for use with
+            <a
+              href="https://security.harvard.edu/data-classification-table"
+              aria-label="Medium Risk Confidential data(L3)"
+            >
+              {' '}
+              Medium Risk Confidential data(L3)
+            </a>{' '}
+            and below. Do not enter any High Risk Confidential data (L4 or
+            above).
+            <br />
+            Before using the AI Sandbox, please review the guidelines and
+            instructions in
+            <a
+              href="https://harvard.service-now.com/ithelp?id=kb_article&sys_id=ca9dd14447f07950566cf147536d433b"
+              aria-label="Getting started with the AI Sandbox"
+            >
+              {' '}
+              “Getting started with the AI Sandbox”
+            </a>
+            .
           </p>
         </div>
       </Drawer>

--- a/src/chainlit/frontend/src/components/Sidebar.tsx
+++ b/src/chainlit/frontend/src/components/Sidebar.tsx
@@ -109,7 +109,7 @@ export default function PersistentDrawerLeft() {
             style={{ width: '18rem' }}
           />
           <h1>AI Sandbox</h1>
-          <h2>(Pilot Version)</h2>
+          <h2 style={{ fontSize: '2em' }}>(Pilot Version)</h2>
           <p>
             Use of this AI Sandbox is subject to data handling practices as
             outlined in the
@@ -131,6 +131,13 @@ export default function PersistentDrawerLeft() {
             and below. Do not enter any High Risk Confidential data (L4 or
             above).
             <br />
+            <Divider
+              sx={{
+                borderColor: theme.palette.mode == 'dark' ? 'white' : 'black',
+                mt: '1rem',
+                mb: '1rem'
+              }}
+            />
             Before using the AI Sandbox, please review the guidelines and
             instructions in
             <a
@@ -141,6 +148,15 @@ export default function PersistentDrawerLeft() {
               “Getting started with the AI Sandbox”
             </a>
             .
+            <br />
+            <Divider
+              sx={{
+                borderColor: theme.palette.mode == 'dark' ? 'white' : 'black',
+                mt: '1rem',
+                mb: '1rem'
+              }}
+            />
+            Chat history cleared at end of session.
           </p>
         </div>
       </Drawer>

--- a/src/chainlit/frontend/src/components/organisms/chat/inputBox/waterMark.tsx
+++ b/src/chainlit/frontend/src/components/organisms/chat/inputBox/waterMark.tsx
@@ -1,19 +1,90 @@
-import { Stack, Typography } from '@mui/material';
+import { useEffect, useState } from 'react';
 
-import { Logo } from 'components/atoms/logo';
+import { Divider, Stack, Typography } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 
 export default function WaterMark() {
+  const theme = useTheme();
+  const [borderColor, setBorderColor] = useState('black');
+  useEffect(() => {
+    setBorderColor(theme.palette.mode == 'dark' ? 'white' : 'black');
+  });
   return (
     <Stack mx="auto">
+      <Stack
+        direction="row"
+        divider={
+          <Divider sx={{ borderColor }} orientation="vertical" flexItem />
+        }
+        spacing={2}
+      >
+        <a
+          href="https://harvard.service-now.com/ithelp?id=kb_article&sys_id=ca9dd14447f07950566cf147536d433b"
+          target="_blank"
+          style={{
+            display: 'flex',
+            textDecoration: 'underline',
+            color: borderColor
+          }}
+          aria-label="Getting started"
+        >
+          <Typography fontSize="12px" color="text.secondary">
+            Getting started
+          </Typography>
+        </a>
+        <a
+          href="https://harvard.az1.qualtrics.com/jfe/form/SV_6A5lw98k350Ey3A"
+          target="_blank"
+          style={{
+            display: 'flex',
+            textDecoration: 'underline',
+            color: borderColor
+          }}
+          aria-label="Feedback"
+        >
+          <Typography fontSize="12px" color="text.secondary">
+            Feedback
+          </Typography>
+        </a>
+        <a
+          href="https://accessibility.huit.harvard.edu/digital-accessibility-policy"
+          target="_blank"
+          style={{
+            display: 'flex',
+            textDecoration: 'underline',
+            color: borderColor
+          }}
+          aria-label="Digital Accessibility"
+        >
+          <Typography fontSize="12px" color="text.secondary">
+            Digital Accessibility
+          </Typography>
+        </a>
+        <a
+          href="https://harvard.service-now.com/ithelp?id=kb_article&sys_id=ed94e064478d71506b944f53636d4380"
+          target="_blank"
+          style={{
+            display: 'flex',
+            textDecoration: 'underline',
+            color: borderColor
+          }}
+          aria-label="Digital Accessibility"
+        >
+          <Typography fontSize="12px" color="text.secondary">
+            Terms of Use / FAQ
+          </Typography>
+        </a>
+      </Stack>
       <a
         href="https://huit.harvard.edu"
         target="_blank"
         style={{
           display: 'flex',
-          alignItems: 'center',
-          textDecoration: 'none'
+          textDecoration: 'none',
+          justifyContent: 'center',
+          color: borderColor
         }}
-        aria-label="Built with link"
+        aria-label="Powered by HUIT"
       >
         <Typography fontSize="12px" color="text.secondary">
           Powered by HUIT

--- a/src/chainlit/frontend/src/components/organisms/dataset/index.tsx
+++ b/src/chainlit/frontend/src/components/organisms/dataset/index.tsx
@@ -1,22 +1,29 @@
-import { Box } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 
+import WaterMark from '../chat/inputBox/waterMark';
 import Filters from './filters';
 import ConversationTable from './table';
 
 export default function Conversation() {
   return (
-    <Box
-      display="flex"
-      flexDirection="column"
-      width="100%"
-      maxWidth="60rem"
-      mx="auto"
-      flexGrow={1}
-    >
-      <Box my={2} />
-      <Filters />
-      <Box my={2} />
-      <ConversationTable />
-    </Box>
+    <>
+      <Box
+        display="flex"
+        flexDirection="column"
+        width="100%"
+        maxWidth="60rem"
+        mx="auto"
+        flexGrow={1}
+      >
+        <Box my={2} />
+        <Typography>Chat history is cleared at end of the session. </Typography>
+        <Filters />
+        <Box my={2} />
+        <ConversationTable />
+      </Box>
+      <Box display="flex" mb="1rem">
+        <WaterMark />
+      </Box>
+    </>
   );
 }

--- a/src/chainlit/frontend/src/components/organisms/dataset/index.tsx
+++ b/src/chainlit/frontend/src/components/organisms/dataset/index.tsx
@@ -16,7 +16,7 @@ export default function Conversation() {
         flexGrow={1}
       >
         <Box my={2} />
-        <Typography>Chat history is cleared at end of the session. </Typography>
+        <Typography>Chat history cleared at end of session. </Typography>
         <Filters />
         <Box my={2} />
         <ConversationTable />

--- a/src/chainlit/frontend/src/components/organisms/header.tsx
+++ b/src/chainlit/frontend/src/components/organisms/header.tsx
@@ -118,8 +118,6 @@ function Nav({ hasDb, hasReadme }: NavProps) {
     tabs.push({ to: '/readme', label: 'Readme' });
   }
 
-  tabs.push({ to: 'https://huit.harvard.edu/ai-sandbox', label: 'About' });
-
   tabs.push({ to: 'https://huit.harvard.edu/', label: 'Help' });
 
   const nav = (


### PR DESCRIPTION
This PR updates the following:
- footer and sidebar with additional links
- wording for chat history
- footer on the history page
<img width="351" alt="Screen Shot 2023-08-31 at 10 13 12 AM" src="https://github.com/Harvard-University-iCommons/chainlit/assets/29421667/d0b380f5-0b5d-41b7-af20-8adf65e3395b">

<img width="1043" alt="Screen Shot 2023-08-31 at 9 26 55 AM" src="https://github.com/Harvard-University-iCommons/chainlit/assets/29421667/1a8b9d5c-a3a7-48fb-8ff3-432f7886e0c7">

<img width="1037" alt="Screen Shot 2023-08-31 at 9 26 44 AM" src="https://github.com/Harvard-University-iCommons/chainlit/assets/29421667/0ab57e94-88d8-4f71-8cb0-2bab27f642b3">


