### PR TITLE
small fix for sizing on mobile view of history

### DIFF
--- a/src/chainlit/frontend/src/components/organisms/chat/inputBox/waterMark.tsx
+++ b/src/chainlit/frontend/src/components/organisms/chat/inputBox/waterMark.tsx
@@ -68,7 +68,7 @@ export default function WaterMark() {
             textDecoration: 'underline',
             color: borderColor
           }}
-          aria-label="Digital Accessibility"
+          aria-label="Terms of Use / FAQ"
         >
           <Typography fontSize="12px" color="text.secondary">
             Terms of Use / FAQ

--- a/src/chainlit/frontend/src/components/organisms/dataset/index.tsx
+++ b/src/chainlit/frontend/src/components/organisms/dataset/index.tsx
@@ -10,7 +10,7 @@ export default function Conversation() {
       <Box
         display="flex"
         flexDirection="column"
-        width="100%"
+        width={{ xs: '90%', lg: '100%' }}
         maxWidth="60rem"
         mx="auto"
         flexGrow={1}


### PR DESCRIPTION
This PR is a small fix for sizing on mobile view of history and a fix for `aria-label=Terms of Use / FAQ`