### PR TITLE
fix footer for history page

### DIFF
--- a/src/chainlit/frontend/src/components/organisms/chat/inputBox/waterMark.tsx
+++ b/src/chainlit/frontend/src/components/organisms/chat/inputBox/waterMark.tsx
@@ -14,7 +14,9 @@ export default function WaterMark() {
       <Box
         sx={{
           display: { xs: 'inline', md: 'flex', lg: 'flex' },
-          justifyContent: 'center'
+          justifyContent: 'center',
+          mx: { xs: '5px' },
+          fontWeight: 500
         }}
       >
         The AI Sandbox may generate responses that are inaccurate, misleading,
@@ -23,7 +25,7 @@ export default function WaterMark() {
           href="https://huit.harvard.edu/ai-sandbox/terms-of-use"
           target="_blank"
           style={{
-            display: 'flex',
+            display: 'inline-block',
             textDecoration: 'underline',
             color: borderColor
           }}
@@ -32,7 +34,11 @@ export default function WaterMark() {
           Terms of Use.
         </a>
       </Box>
-      <Stack mx="auto">
+      <Stack
+        sx={{
+          mx: { xs: '5px', md: 'auto', lg: 'auto' }
+        }}
+      >
         <Stack
           direction="row"
           divider={

--- a/src/chainlit/frontend/src/components/organisms/dataset/index.tsx
+++ b/src/chainlit/frontend/src/components/organisms/dataset/index.tsx
@@ -21,9 +21,7 @@ export default function Conversation() {
         <Box my={2} />
         <ConversationTable />
       </Box>
-      <Box display="flex" mb="1rem">
-        <WaterMark />
-      </Box>
+      <WaterMark />
     </>
   );
 }


### PR DESCRIPTION
This PR should fix the footer on the `History` page, the `link` not on the same line as the disclaimer and the boldness of the font
<img width="379" alt="Screen Shot 2023-09-05 at 11 37 12 AM" src="https://github.com/Harvard-University-iCommons/chainlit/assets/29421667/2ec7e9ea-2dbd-4e8d-bd11-c1efa5060fdc">
<img width="1074" alt="Screen Shot 2023-09-05 at 11 37 00 AM" src="https://github.com/Harvard-University-iCommons/chainlit/assets/29421667/2ae0784c-cf79-40e0-9620-b85461ec454d">
