### PR TITLE
fix wrap for chat when sidebar is opened

### DIFF
--- a/src/chainlit/frontend/src/components/Sidebar.tsx
+++ b/src/chainlit/frontend/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { huitColorPaletteV3 } from 'palette';
-import * as React from 'react';
+import { useState } from 'react';
 import { useMediaQuery } from 'usehooks-ts';
 
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
@@ -50,7 +50,7 @@ const DrawerHeader = styled('div')(({ theme }) => ({
 export default function PersistentDrawerLeft() {
   const theme = useTheme();
   const matches = useMediaQuery('(max-width:480px');
-  const [open, setOpen] = React.useState(matches ? false : true);
+  const [open, setOpen] = useState(matches ? false : true);
 
   const handleDrawerOpen = () => {
     setOpen(true);

--- a/src/chainlit/frontend/src/components/atoms/element/sideView.tsx
+++ b/src/chainlit/frontend/src/components/atoms/element/sideView.tsx
@@ -168,7 +168,6 @@ const MainDrawer = styled(Box, {
   shouldForwardProp: (prop) => prop !== 'open'
 })<MainDrawerProps>(({ theme, open, width = DRAWER_DEFAULT_WIDTH }) => ({
   width: '100%',
-  marginRight: !open && theme.breakpoints.up('sm') ? -width : 0,
   display: 'flex',
   flexDirection: 'column',
   boxSizing: 'border-box',

--- a/src/chainlit/frontend/src/components/organisms/chat/index.tsx
+++ b/src/chainlit/frontend/src/components/organisms/chat/index.tsx
@@ -122,8 +122,8 @@ const Chat = () => {
       <ChatSettingsModal />
       <TaskList tasklist={tasklist} isMobile={false} />
       <SideView>
+        <Box mx={1} />
         <TaskList tasklist={tasklist} isMobile={true} />
-        <Box my={1} />
         {session?.error && (
           <Alert id="session-error" severity="error">
             Unable to contact the sandbox. Please refresh the page and contact


### PR DESCRIPTION
This PR is to fix the chat window getting cut off when the sidebar is opened on certain screen sizes.
Note: Mobile view will have the chat window blocked by the `Sidebar` until the `Sidebar` is collapsed, but by default the `Sidebar` is closed in mobile view
<img width="870" alt="Screen Shot 2023-09-07 at 4 49 36 PM" src="https://github.com/Harvard-University-iCommons/chainlit/assets/29421667/36940852-1d32-48ac-93f7-8cf1eb006c57">
<img width="1034" alt="Screen Shot 2023-09-07 at 4 49 18 PM" src="https://github.com/Harvard-University-iCommons/chainlit/assets/29421667/069ffa14-6cb6-485a-8b29-7bb91360617e">
