### PR TITLE
fix a11y for user, nav, and show history menu

### DIFF
--- a/src/chainlit/frontend/src/components/Sidebar.tsx
+++ b/src/chainlit/frontend/src/components/Sidebar.tsx
@@ -76,7 +76,7 @@ export default function PersistentDrawerLeft() {
         onClick={handleDrawerOpen}
         edge="start"
         sx={{
-          position: 'inherit',
+          position: 'sticky',
           mb: { xs: '25rem', md: '14rem', lg: '14rem' },
           ml: '2px',
           mr: 0,

--- a/src/chainlit/frontend/src/components/atoms/buttons/userButton/menu.tsx
+++ b/src/chainlit/frontend/src/components/atoms/buttons/userButton/menu.tsx
@@ -10,8 +10,8 @@ import {
   ListItem,
   ListItemIcon,
   ListItemText,
-  Menu,
   MenuItem,
+  Popover,
   Typography
 } from '@mui/material';
 
@@ -46,11 +46,35 @@ export default function UserMenu({ anchorEl, open, handleClose }: Props) {
   const settingsItem = (
     <>
       <MenuItem
+        key="close"
+        aria-label="Close options menu"
+        onClick={() => {
+          handleClose();
+        }}
+        tabIndex={0}
+        sx={{
+          pr: 0,
+          pb: { xs: 0, sm: '10px', md: 1, lg: 1 },
+          pt: { xs: 0, sm: '10px', md: 1, lg: 1 },
+          mb: { xs: '-5px' }
+        }}
+      >
+        <ListItemIcon sx={{ marginLeft: 'auto', height: 20 }}>
+          <CloseIcon
+            fontSize="small"
+            aria-label="Close icon"
+            sx={{ minWidth: { xs: 50, sm: 50, md: 50, lg: 50 } }}
+          />
+        </ListItemIcon>
+      </MenuItem>
+      <Divider />
+      <MenuItem
         key="settings"
         onClick={() => {
           setAppSettings((old) => ({ ...old, open: true }));
           handleClose();
         }}
+        tabIndex={0}
       >
         <ListItemIcon>
           <SettingsIcon fontSize="small" aria-label="Settings Menu" />
@@ -58,6 +82,7 @@ export default function UserMenu({ anchorEl, open, handleClose }: Props) {
         <ListItemText>Settings</ListItemText>
       </MenuItem>
       <MenuItem
+        tabIndex={0}
         key="logout"
         onClick={() => {
           // redirect to IdP logout URL
@@ -73,21 +98,6 @@ export default function UserMenu({ anchorEl, open, handleClose }: Props) {
           />
         </ListItemIcon>
         <ListItemText>Logout</ListItemText>
-      </MenuItem>
-      <MenuItem
-        key="close"
-        onClick={() => {
-          handleClose();
-        }}
-      >
-        <ListItemIcon>
-          <CloseIcon
-            style={{ paddingLeft: 0 }}
-            fontSize="small"
-            aria-label="close settings"
-          />
-        </ListItemIcon>
-        <ListItemText>Close</ListItemText>
       </MenuItem>
     </>
   );
@@ -135,7 +145,8 @@ export default function UserMenu({ anchorEl, open, handleClose }: Props) {
   }, [] as React.ReactNode[]);
 
   return (
-    <Menu
+    <Popover
+      tabIndex={0}
       anchorEl={anchorEl}
       id="account-menu"
       open={open}
@@ -155,19 +166,8 @@ export default function UserMenu({ anchorEl, open, handleClose }: Props) {
             width: 32,
             height: 32,
             ml: -0.5,
-            mr: 1
-          },
-          '&:before': {
-            content: '""',
-            display: 'block',
-            position: 'absolute',
-            top: 0,
-            right: 14,
-            width: 10,
-            height: 10,
-            bgcolor: 'background.default',
-            transform: 'translateY(-50%) rotate(45deg)',
-            zIndex: 0
+            mr: 1,
+            tabIndex: 0
           }
         }
       }}
@@ -175,6 +175,6 @@ export default function UserMenu({ anchorEl, open, handleClose }: Props) {
       anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
     >
       {itemsWithDivider}
-    </Menu>
+    </Popover>
   );
 }

--- a/src/chainlit/frontend/src/components/organisms/chat/history/index.tsx
+++ b/src/chainlit/frontend/src/components/organisms/chat/history/index.tsx
@@ -5,11 +5,14 @@ import { useRef, useState } from 'react';
 import { useRecoilState } from 'recoil';
 
 import { AutoDelete } from '@mui/icons-material';
+import CloseIcon from '@mui/icons-material/Close';
 import KeyboardDoubleArrowUpIcon from '@mui/icons-material/KeyboardDoubleArrowUp';
 import {
+  Box,
+  Divider,
   IconButton,
-  Menu,
   MenuItem,
+  Popover,
   Stack,
   Tooltip,
   Typography
@@ -74,28 +77,44 @@ export default function HistoryButton({ onClick }: Props) {
   const toggleChatHistoryMenu = (open: boolean) =>
     setChatHistory((old) => ({ ...old, open }));
 
+  const toggleOnKeyDown = (code: string) =>
+    code === 'Enter' || code === 'Space'
+      ? toggleChatHistoryMenu(!chatHistory.open)
+      : null;
+
   const header = (
-    // @ts-ignore
-    <Stack
-      disabled
-      key="title"
-      direction="row"
-      p={1}
-      justifyContent="space-between"
-      alignItems="center"
-    >
+    <Box>
+      <Stack
+        key="title"
+        sx={{
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          pt: 1
+        }}
+      >
+        <IconButton
+          aria-label="close show history"
+          onClick={() => toggleChatHistoryMenu(false)}
+          onKeyDown={(event) => toggleOnKeyDown(event.code)}
+        >
+          <CloseIcon />
+        </IconButton>
+
+        <IconButton
+          onClick={() => setChatHistory((old) => ({ ...old, messages: [] }))}
+        >
+          <AutoDelete />
+        </IconButton>
+      </Stack>
       <Typography
         color="text.primary"
-        sx={{ fontSize: '14px', fontWeight: 700 }}
+        sx={{ fontSize: '20px', fontWeight: 500, padding: 1 }}
       >
         Last messages
       </Typography>
-      <IconButton
-        onClick={() => setChatHistory((old) => ({ ...old, messages: [] }))}
-      >
-        <AutoDelete />
-      </IconButton>
-    </Stack>
+      <Divider />
+    </Box>
   );
 
   const empty =
@@ -176,6 +195,7 @@ export default function HistoryButton({ onClick }: Props) {
               alignItems: 'baseline',
               borderRadius: '4px'
             }}
+            tabIndex={0}
           >
             <Typography
               color="text.primary"
@@ -201,8 +221,7 @@ export default function HistoryButton({ onClick }: Props) {
   }
 
   const menu = anchorEl ? (
-    <Menu
-      autoFocus
+    <Popover
       anchorEl={anchorEl}
       open={chatHistory.open}
       onClose={() => toggleChatHistoryMenu(false)}
@@ -227,7 +246,7 @@ export default function HistoryButton({ onClick }: Props) {
       transformOrigin={{ vertical: 'bottom', horizontal: 'left' }}
     >
       {menuEls}
-    </Menu>
+    </Popover>
   ) : null;
 
   return (
@@ -238,6 +257,8 @@ export default function HistoryButton({ onClick }: Props) {
           color="inherit"
           onClick={() => toggleChatHistoryMenu(!chatHistory.open)}
           ref={ref}
+          onKeyDown={(event) => toggleOnKeyDown(event.code)}
+          aria-label="show history"
         >
           <KeyboardDoubleArrowUpIcon />
         </IconButton>

--- a/src/chainlit/frontend/src/components/organisms/header.tsx
+++ b/src/chainlit/frontend/src/components/organisms/header.tsx
@@ -3,14 +3,17 @@ import { useRef, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 
+import CloseIcon from '@mui/icons-material/Close';
 import MenuIcon from '@mui/icons-material/Menu';
 import {
   AppBar,
   Box,
   Button,
+  Divider,
   IconButton,
-  Menu,
+  ListItemIcon,
   MenuItem,
+  Popover,
   Stack,
   Toolbar,
   useTheme
@@ -71,7 +74,9 @@ const styleOverrides = {
         theme.palette.mode === 'dark'
           ? huitColorPaletteV3.white
           : theme.palette.primary.light
-    }
+    },
+    marginTop: 1,
+    marginBottom: 1
   }
 };
 
@@ -161,8 +166,7 @@ function Nav({ hasDb, hasReadme }: NavProps) {
         >
           <MenuIcon />
         </IconButton>
-        <Menu
-          autoFocus
+        <Popover
           anchorEl={anchorEl}
           open={open}
           onClose={() => setOpen(false)}
@@ -184,23 +188,41 @@ function Nav({ hasDb, hasReadme }: NavProps) {
           anchorOrigin={{ vertical: 'top', horizontal: 'left' }}
           transformOrigin={{ vertical: 'bottom', horizontal: 'left' }}
         >
-          {tabs.map((t, index) => {
+          <MenuItem
+            key="close"
+            aria-label="Close navigation menu"
+            onClick={() => {
+              setOpen(false);
+            }}
+            tabIndex={0}
+            sx={{ pr: 0, pb: 0, pt: { xs: 0, sm: 1 }, mt: '-5px', mb: '-5px' }}
+          >
+            <ListItemIcon sx={{ marginLeft: 'auto', height: 20 }}>
+              <CloseIcon
+                fontSize="small"
+                aria-label="Close icon"
+                sx={{ minWidth: '40px' }}
+              />
+            </ListItemIcon>
+          </MenuItem>
+          <Divider />
+          {tabs.map((t) => {
             const active = location.pathname === t.to;
             return active ? (
-              <ActiveMenuItem {...t} tabIndex={index} />
+              <ActiveMenuItem {...t} tabIndex={0} />
             ) : (
               <MenuItem
                 sx={styleOverrides.inactive}
                 key={t.to}
                 component={Link}
                 to={t.to}
-                tabIndex={index}
+                tabIndex={0}
               >
                 {t.label}
               </MenuItem>
             );
           })}
-        </Menu>
+        </Popover>
       </>
     );
   } else {


### PR DESCRIPTION
This PR fixes the following issues #31 #32 #30 #29 :
- Tab functionality for user, mobile nav, and show history menu
- Added close icons to user, mobile nav, and show history menu


![Screen Shot 2023-09-14 at 1 26 45 PM](https://github.com/Harvard-University-iCommons/chainlit/assets/29421667/aa7d449e-65a7-4b07-af45-fbd5165925ff)
![Screen Shot 2023-09-14 at 9 22 56 AM](https://github.com/Harvard-University-iCommons/chainlit/assets/29421667/6813c0f9-00d9-4ca5-9e30-6f7ba948ebdb)
![Screen Shot 2023-09-14 at 9 22 42 AM](https://github.com/Harvard-University-iCommons/chainlit/assets/29421667/d5c6e65d-9688-4c41-84dc-e18e983e5859)
