### PR TITLE
added version to frontend api call

### DIFF
--- a/src/chainlit/frontend/src/components/molecules/settingsModal.tsx
+++ b/src/chainlit/frontend/src/components/molecules/settingsModal.tsx
@@ -1,4 +1,4 @@
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 
 import CloseIcon from '@mui/icons-material/Close';
 import DarkModeOutlined from '@mui/icons-material/DarkModeOutlined';
@@ -18,10 +18,11 @@ import {
 
 import Switch from 'components/atoms/switch';
 
-import { settingsState } from 'state/settings';
+import { settingsState, versionState } from 'state/settings';
 
 export default function SettingsModal() {
   const [settings, setSettings] = useRecoilState(settingsState);
+  const { version } = useRecoilValue(versionState);
   const handleClose = () => setSettings((old) => ({ ...old, open: false }));
   return (
     <Dialog
@@ -107,6 +108,7 @@ export default function SettingsModal() {
               />
             </Box>
           </ListItem>
+          {version ? <ListItem> Version: {version} </ListItem> : ''}
         </List>
       </DialogContent>
     </Dialog>

--- a/src/chainlit/frontend/src/components/organisms/chat/inputBox/waterMark.tsx
+++ b/src/chainlit/frontend/src/components/organisms/chat/inputBox/waterMark.tsx
@@ -13,7 +13,7 @@ export default function WaterMark() {
     <>
       <Box
         sx={{
-          display: { xs: 'inline', md: 'flex', lg: 'flex' },
+          display: { xs: 'inline', sm: 'inline', md: 'inline', lg: 'flex' },
           justifyContent: 'center',
           mx: { xs: '5px' },
           fontWeight: 500

--- a/src/chainlit/frontend/src/state/settings.ts
+++ b/src/chainlit/frontend/src/state/settings.ts
@@ -1,4 +1,6 @@
-import { atom } from 'recoil';
+import { atom, selector } from 'recoil';
+
+import { wsEndpoint } from '../api';
 
 type ThemeVariant = 'dark' | 'light';
 
@@ -23,4 +25,22 @@ export const settingsState = atom<{
     hideCot: false,
     theme
   }
+});
+
+export const versionState = atom<{
+  version: string;
+}>({
+  key: 'version',
+  default: selector({
+    key: 'version/default',
+    get: async () => {
+      const res = await fetch(`${wsEndpoint}/version`, {
+        headers: {
+          'content-type': 'application/json'
+        },
+        method: 'GET'
+      });
+      return res.json();
+    }
+  })
 });


### PR DESCRIPTION
This PR adds an api call that set frontend state `version` via `RecoilJs`. Reference [issue#59](https://github.com/harvard-ea/ask-ai/issues/59)
Note: that is just an example of the version#
<img width="370" alt="Screen Shot 2023-09-21 at 9 24 34 AM" src="https://github.com/Harvard-University-iCommons/chainlit/assets/29421667/1b47c28f-5099-4a48-ad0e-82873e68abe8">
