### PR TITLE
added aria-live to chat and stopButton

### DIFF
--- a/src/chainlit/frontend/src/components/organisms/chat/history/index.tsx
+++ b/src/chainlit/frontend/src/components/organisms/chat/history/index.tsx
@@ -222,6 +222,7 @@ export default function HistoryButton({ onClick }: Props) {
 
   const menu = anchorEl ? (
     <Popover
+      key="menu"
       anchorEl={anchorEl}
       open={chatHistory.open}
       onClose={() => toggleChatHistoryMenu(false)}

--- a/src/chainlit/frontend/src/components/organisms/chat/message/container.tsx
+++ b/src/chainlit/frontend/src/components/organisms/chat/message/container.tsx
@@ -1,9 +1,15 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { useRecoilValue } from 'recoil';
 
 import { Box } from '@mui/material';
 
 import { IAction } from 'state/action';
-import { IMessage, INestedMessage } from 'state/chat';
+import {
+  IMessage,
+  INestedMessage,
+  chatToolValueState,
+  loadingState
+} from 'state/chat';
 import { IMessageElement } from 'state/element';
 
 import Messages from './messages';
@@ -99,7 +105,9 @@ const MessageContainer = ({
 }: Props) => {
   const ref = useRef<HTMLDivElement>();
   const nestedMessages = nestMessages(messages);
-
+  const [lastMessage, setLastMessage] = useState({}) as any;
+  const loading = useRecoilValue(loadingState);
+  const tool = useRecoilValue(chatToolValueState);
   useEffect(() => {
     if (!ref.current || !autoScroll) {
       return;
@@ -114,6 +122,17 @@ const MessageContainer = ({
     const atBottom = scrollTop + clientHeight >= scrollHeight - 10;
     setAutoScroll(atBottom);
   };
+
+  const usingToolText = tool.length > 0 ? `Using ${tool}` : 'Running';
+
+  useEffect(() => {
+    if (
+      nestedMessages.length > 0 &&
+      lastMessage.content !== nestedMessages[nestedMessages.length - 1].content
+    ) {
+      setLastMessage(nestedMessages[nestedMessages.length - 1]);
+    }
+  });
 
   return (
     <Box
@@ -131,6 +150,23 @@ const MessageContainer = ({
         elements={elements}
         actions={actions}
       />
+      <Box
+        aria-live="assertive"
+        aria-atomic={true}
+        id="chat-al-region"
+        style={{
+          border: 0,
+          clip: 'rect(0 0 0 0)',
+          height: '1px',
+          margin: '-1px',
+          overflow: 'hidden',
+          padding: 0,
+          width: '1px',
+          position: 'absolute'
+        }}
+      >
+        {lastMessage && !loading ? lastMessage.content : usingToolText}
+      </Box>
     </Box>
   );
 };

--- a/src/chainlit/frontend/src/components/organisms/chat/message/detailsButton.tsx
+++ b/src/chainlit/frontend/src/components/organisms/chat/message/detailsButton.tsx
@@ -1,4 +1,5 @@
-import { useRecoilValue } from 'recoil';
+import { useEffect } from 'react';
+import { useRecoilState, useRecoilValue } from 'recoil';
 
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
@@ -6,7 +7,7 @@ import CircularProgress from '@mui/material/CircularProgress';
 
 import GreyButton from 'components/atoms/buttons/greyButton';
 
-import { INestedMessage } from 'state/chat';
+import { INestedMessage, chatToolValueState } from 'state/chat';
 import { settingsState } from 'state/settings';
 
 interface Props {
@@ -23,6 +24,7 @@ export default function DetailsButton({
   loading
 }: Props) {
   const { hideCot } = useRecoilValue(settingsState);
+  const [toolValue, setToolValue] = useRecoilState(chatToolValueState);
 
   const nestedCount = message.subMessages?.length;
   const nested = !!nestedCount;
@@ -30,6 +32,12 @@ export default function DetailsButton({
   const tool = nested
     ? message.subMessages![nestedCount - 1].author
     : undefined;
+
+  useEffect(() => {
+    if (tool && tool !== toolValue) {
+      setToolValue(tool);
+    }
+  });
 
   const isRunningEmptyStep = loading && !message.content;
   const isRunningUserMessage = loading && message.authorIsUser;

--- a/src/chainlit/frontend/src/components/organisms/chat/stopButton.tsx
+++ b/src/chainlit/frontend/src/components/organisms/chat/stopButton.tsx
@@ -21,7 +21,7 @@ export default function StopButton() {
   };
 
   return (
-    <Box margin="auto">
+    <Box margin="auto" aria-live="polite">
       <GreyButton
         id="stop-button"
         startIcon={<CloseIcon />}

--- a/src/chainlit/frontend/src/components/organisms/header.tsx
+++ b/src/chainlit/frontend/src/components/organisms/header.tsx
@@ -167,6 +167,7 @@ function Nav({ hasDb, hasReadme }: NavProps) {
           <MenuIcon />
         </IconButton>
         <Popover
+          key="nav dropdown"
           anchorEl={anchorEl}
           open={open}
           onClose={() => setOpen(false)}

--- a/src/chainlit/frontend/src/state/chat.ts
+++ b/src/chainlit/frontend/src/state/chat.ts
@@ -144,3 +144,9 @@ export const chatSettingsValueState = atom({
   key: 'ChatSettingsValue',
   default: chatSettingsDefaultValueSelector
 });
+
+export const chatToolValueState = atom({
+  key: 'chatToolValueState',
+  dangerouslyAllowMutability: true,
+  default: ''
+});


### PR DESCRIPTION
This PR adds a separate html element for `aria-live` announcements originating from the chat message components and adds `aria-live` to the `stopButton` component. Reference issue #19 #24 