### PR TITLE
Strips out the ** when chat is added to aria live region

### DIFF
--- a/src/chainlit/frontend/src/components/organisms/chat/message/container.tsx
+++ b/src/chainlit/frontend/src/components/organisms/chat/message/container.tsx
@@ -130,7 +130,15 @@ const MessageContainer = ({
       nestedMessages.length > 0 &&
       lastMessage.content !== nestedMessages[nestedMessages.length - 1].content
     ) {
-      setLastMessage(nestedMessages[nestedMessages.length - 1]);
+      const message = { ...nestedMessages[nestedMessages.length - 1] };
+      const targetSubstring = `**${message.author}:**`;
+      if (message.content?.includes(targetSubstring)) {
+        message.content = message.content?.replace(
+          targetSubstring,
+          `${message.author}:`
+        );
+      }
+      setLastMessage(message);
     }
   });
 


### PR DESCRIPTION
This PR strips out the asterisk `*` character from the LLM name when adding them to the aria-live region so that the screen reader does not announce `asterisk`.