### PR TITLE
add aria-live to dataset/history search bar and table

### DIFF
--- a/src/chainlit/frontend/src/components/organisms/dataset/filters/SearchBar.tsx
+++ b/src/chainlit/frontend/src/components/organisms/dataset/filters/SearchBar.tsx
@@ -66,7 +66,7 @@ export default function SearchBar() {
   };
 
   return (
-    <Search>
+    <Search aria-live="polite">
       <SearchIconWrapper
         sx={{
           position: 'absolute',

--- a/src/chainlit/frontend/src/components/organisms/dataset/table.tsx
+++ b/src/chainlit/frontend/src/components/organisms/dataset/table.tsx
@@ -144,6 +144,7 @@ export default function ConversationTable() {
           alignItems: 'center',
           borderBottom: (theme) => `1px solid ${theme.palette.divider}`
         }}
+        aria-live="polite"
       >
         <RowText text={conversation.id} col={columns['Id']} />
         <RowText


### PR DESCRIPTION
This PR adds aria-live to the history page and the search bar so the screen reader can pick up changes. Reference issue #27 